### PR TITLE
feat(ui): NinerLog design system polish — gorgeous mobile / iPad UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.svg" />
+    <link rel="mask-icon" href="/favicon.svg" color="#2563EB" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="EASA/FAA Compliant Pilot Logbook" />
-    <meta name="theme-color" content="#2563eb" />
+    <meta name="theme-color" content="#1E3A5F" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#2563EB" media="(prefers-color-scheme: light)" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="NinerLog" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" />

--- a/public/apple-touch-icon.svg
+++ b/public/apple-touch-icon.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Maskable PWA icon (180x180 base, with safe-zone padding so iOS rounded mask never clips the mark) -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 180 180" role="img" aria-label="NinerLog">
+  <defs>
+    <linearGradient id="nl-bg-apple" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E3A5F"/>
+      <stop offset="60%" stop-color="#1D4ED8"/>
+      <stop offset="100%" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="180" fill="url(#nl-bg-apple)"/>
+  <g transform="translate(22.5,22.5) scale(0.26)">
+    <rect x="80" y="320" width="352" height="10" rx="5" fill="#FFFFFF" opacity="0.6"/>
+    <path d="M96 280 L256 144 L416 280 L376 280 L256 196 L136 280 Z" fill="#FFFFFF"/>
+    <path d="M196 256 L256 212 L316 256 L292 256 L256 232 L220 256 Z" fill="#FFFFFF" opacity="0.55"/>
+    <circle cx="256" cy="372" r="10" fill="#FFFFFF" opacity="0.9"/>
+  </g>
+</svg>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="NinerLog">
+  <defs>
+    <linearGradient id="nl-bg-fav" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E3A5F"/>
+      <stop offset="60%" stop-color="#1D4ED8"/>
+      <stop offset="100%" stop-color="#2563EB"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="7" ry="7" fill="url(#nl-bg-fav)"/>
+  <!-- Horizon -->
+  <rect x="5" y="20" width="22" height="1.4" rx="0.7" fill="#FFFFFF" opacity="0.6"/>
+  <!-- Wing -->
+  <path d="M6 17.5 L16 9 L26 17.5 L23.5 17.5 L16 11.6 L8.5 17.5 Z" fill="#FFFFFF"/>
+  <circle cx="16" cy="23.4" r="0.9" fill="#FFFFFF" opacity="0.9"/>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="NinerLog">
+  <defs>
+    <linearGradient id="nl-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1E3A5F"/>
+      <stop offset="55%" stop-color="#1D4ED8"/>
+      <stop offset="100%" stop-color="#2563EB"/>
+    </linearGradient>
+    <linearGradient id="nl-shine" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.18"/>
+      <stop offset="55%" stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <!-- Rounded badge -->
+  <rect x="0" y="0" width="512" height="512" rx="112" ry="112" fill="url(#nl-bg)"/>
+  <!-- Subtle top shine -->
+  <rect x="0" y="0" width="512" height="512" rx="112" ry="112" fill="url(#nl-shine)"/>
+  <!-- Horizon line -->
+  <rect x="80" y="320" width="352" height="10" rx="5" fill="#FFFFFF" opacity="0.55"/>
+  <!-- Wing / chevron mark -->
+  <path d="M96 280 L256 144 L416 280 L376 280 L256 196 L136 280 Z"
+        fill="#FFFFFF"/>
+  <!-- Inner vapor stripe -->
+  <path d="M196 256 L256 212 L316 256 L292 256 L256 232 L220 256 Z"
+        fill="#FFFFFF" opacity="0.55"/>
+  <!-- Small altitude dot -->
+  <circle cx="256" cy="372" r="10" fill="#FFFFFF" opacity="0.85"/>
+</svg>

--- a/src/components/currency/CurrencyCard.tsx
+++ b/src/components/currency/CurrencyCard.tsx
@@ -1,37 +1,42 @@
 import { useTranslation } from 'react-i18next';
+import { ShieldCheck, ShieldAlert, ShieldX, Shield, Calendar } from 'lucide-react';
 import type { ClassRatingCurrency, CurrencyRequirement, CurrencyStatus } from '../../types/api';
 import { useFormatPrefs } from '../../hooks/useFormatPrefs';
 
 const STATUS_CONFIG: Record<CurrencyStatus, {
-  bg: string; border: string; badge: string; badgeKey: string; icon: string;
+  bg: string; border: string; iconWrap: string; badge: string; badgeKey: string; Icon: typeof Shield;
 }> = {
   current: {
-    bg: 'bg-green-50 dark:bg-green-900/20',
-    border: 'border-l-green-500',
+    bg: 'bg-gradient-to-br from-green-50/70 via-white to-green-50/30 dark:from-green-900/15 dark:via-slate-800 dark:to-slate-800',
+    border: 'border-l-4 border-l-green-500',
+    iconWrap: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300 ring-2 ring-green-500/15',
     badge: 'badge-current',
     badgeKey: 'status.current',
-    icon: '✓',
+    Icon: ShieldCheck,
   },
   expiring: {
-    bg: 'bg-amber-50 dark:bg-amber-900/20',
-    border: 'border-l-amber-500',
+    bg: 'bg-gradient-to-br from-amber-50/70 via-white to-amber-50/30 dark:from-amber-900/15 dark:via-slate-800 dark:to-slate-800',
+    border: 'border-l-4 border-l-amber-500',
+    iconWrap: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 ring-2 ring-amber-500/15',
     badge: 'badge-expiring',
     badgeKey: 'status.attention',
-    icon: '⏰',
+    Icon: ShieldAlert,
   },
   expired: {
-    bg: 'bg-red-50 dark:bg-red-900/20',
-    border: 'border-l-red-500',
+    bg: 'bg-gradient-to-br from-red-50/70 via-white to-red-50/30 dark:from-red-900/15 dark:via-slate-800 dark:to-slate-800',
+    border: 'border-l-4 border-l-red-500',
+    iconWrap: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300 ring-2 ring-red-500/15',
     badge: 'badge-expired',
     badgeKey: 'status.notCurrent',
-    icon: '✕',
+    Icon: ShieldX,
   },
   unknown: {
-    bg: 'bg-slate-50 dark:bg-slate-800/40',
-    border: 'border-l-slate-400',
+    bg: 'bg-white dark:bg-slate-800',
+    border: 'border-l-4 border-l-slate-300 dark:border-l-slate-600',
+    iconWrap: 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-300',
     badge: 'badge-neutral',
     badgeKey: 'status.unknown',
-    icon: '?',
+    Icon: Shield,
   },
 };
 
@@ -51,16 +56,19 @@ function RequirementBar({ req }: { req: CurrencyRequirement }) {
   return (
     <div className="space-y-1" data-testid={`requirement-${req.name}`}>
       <div className="flex justify-between items-center text-xs">
-        <span className="font-medium text-slate-700 dark:text-slate-300">
-          {req.met ? '✓' : '○'} {req.name}
+        <span className="font-medium text-slate-700 dark:text-slate-300 inline-flex items-center gap-1">
+          <span aria-hidden="true" className={req.met ? 'text-green-600 dark:text-green-400' : 'text-slate-400'}>
+            {req.met ? '✓' : '○'}
+          </span>
+          {req.name}
         </span>
-        <span className="text-slate-500 dark:text-slate-400">
+        <span className="text-slate-500 dark:text-slate-400 font-mono tabular-nums">
           {displayMessage}
         </span>
       </div>
       <div className="h-1.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
         <div
-          className={`h-full rounded-full transition-all ${barColor}`}
+          className={`h-full rounded-full transition-all duration-500 ease-out ${barColor}`}
           style={{ width: `${pct}%` }}
           data-testid={`progress-bar-${req.name}`}
         />
@@ -77,25 +85,33 @@ export function CurrencyCard({ rating }: CurrencyCardProps) {
   const { t } = useTranslation('currency');
   const { fmtDate } = useFormatPrefs();
   const config = STATUS_CONFIG[rating.status];
+  const StatusIcon = config.Icon;
   const label = t(`classTypes.${rating.classType}`, { defaultValue: rating.classType });
 
   return (
     <div
-      className={`card border-l-4 ${config.border} ${config.bg}`}
+      className={`card hover-lift ${config.border} ${config.bg}`}
       data-testid={`currency-card-${rating.classRatingId}`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <h3 className="font-semibold text-slate-800 dark:text-slate-100 flex items-center gap-2">
-            <span>{config.icon}</span>
-            {label}
-          </h3>
-          <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
-            {rating.regulatoryAuthority} {rating.licenseType || ''}
-          </p>
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex items-start gap-3 min-w-0">
+          <span
+            className={`shrink-0 inline-flex items-center justify-center w-10 h-10 rounded-lg ${config.iconWrap}`}
+            aria-hidden="true"
+          >
+            <StatusIcon className="w-5 h-5" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="font-semibold text-slate-800 dark:text-slate-100 truncate">
+              {label}
+            </h3>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+              {rating.regulatoryAuthority} {rating.licenseType || ''}
+            </p>
+          </div>
         </div>
-        <span className={`${config.badge}`}>
+        <span className={`${config.badge} shrink-0`}>
           {t(config.badgeKey).toUpperCase()}
         </span>
       </div>
@@ -120,10 +136,13 @@ export function CurrencyCard({ rating }: CurrencyCardProps) {
           <p className="text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">{t('launchMethod')}</p>
           {rating.launchMethodCurrency.map((lmc) => (
             <div key={lmc.method} className="flex justify-between items-center text-xs" data-testid={`launch-method-${lmc.method}`}>
-              <span className="text-slate-700 dark:text-slate-300">
-                {lmc.met ? '✓' : '○'} {lmc.method}
+              <span className="text-slate-700 dark:text-slate-300 inline-flex items-center gap-1">
+                <span aria-hidden="true" className={lmc.met ? 'text-green-600 dark:text-green-400' : 'text-slate-400'}>
+                  {lmc.met ? '✓' : '○'}
+                </span>
+                {lmc.method}
               </span>
-              <span className="text-slate-500 dark:text-slate-400">
+              <span className="text-slate-500 dark:text-slate-400 font-mono tabular-nums">
                 {t('launchesCount', { current: lmc.launches, required: lmc.required })}
               </span>
             </div>
@@ -133,7 +152,8 @@ export function CurrencyCard({ rating }: CurrencyCardProps) {
 
       {/* Expiry date */}
       {rating.expiryDate && (
-        <p className="text-xs text-slate-400 dark:text-slate-500 mt-3 text-right">
+        <p className="text-xs text-slate-400 dark:text-slate-500 mt-3 text-right inline-flex items-center gap-1 justify-end w-full">
+          <Calendar className="w-3 h-3" aria-hidden="true" />
           {t('expiresLabel', { date: fmtDate(rating.expiryDate) })}
         </p>
       )}

--- a/src/components/flights/FlightCard.tsx
+++ b/src/components/flights/FlightCard.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, PlaneTakeoff, PlaneLanding, Calendar } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { components } from '../../api/schema';
 import { useFormatPrefs } from '../../hooks/useFormatPrefs';
@@ -17,36 +17,38 @@ export default function FlightCard({ flight, onEdit, onDelete, onClick }: Flight
   const totalLandings = flight.landingsDay + flight.landingsNight;
   const { fmtDuration, fmtDate } = useFormatPrefs();
 
+  const offBlock = (flight.offBlockTime || flight.departureTime)?.slice(0, 5);
+  const onBlock = (flight.onBlockTime || flight.arrivalTime)?.slice(0, 5);
+
   return (
     <div
-      className="card hover:shadow-md transition-shadow cursor-pointer"
+      className="card hover-lift tap-none"
       onClick={onClick}
       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }}
       role="button"
       tabIndex={0}
       aria-label={`Flight ${flight.departureIcao || '—'} to ${flight.arrivalIcao || '—'} on ${fmtDate(flight.date)}, ${fmtDuration(flight.totalTime)}`}
     >
-      <div className="flex justify-between items-start mb-3">
-        <div>
-          <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">
-            {flight.departureIcao || '—'} → {flight.arrivalIcao || '—'}
+      {/* Route hero */}
+      <div className="flex items-center gap-3 mb-3">
+        <span className="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300 shrink-0" aria-hidden="true">
+          <PlaneTakeoff className="w-[18px] h-[18px]" />
+        </span>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold font-mono tabular-nums text-slate-800 dark:text-slate-100 tracking-tight">
+            {(flight.departureIcao || '—') + ' → ' + (flight.arrivalIcao || '—')}
           </h3>
-          <p className="text-sm text-slate-500 dark:text-slate-400">
+          <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 inline-flex items-center gap-1.5 flex-wrap">
+            <Calendar className="w-3 h-3" aria-hidden="true" />
             {fmtDate(flight.date)}
-            {(flight.offBlockTime || flight.departureTime || flight.arrivalTime || flight.onBlockTime) && (
-              <span className="ml-2 font-mono tabular-nums text-xs">
-                {(flight.offBlockTime || flight.departureTime)
-                  ? (flight.offBlockTime || flight.departureTime)!.slice(0, 5)
-                  : '—'}
-                {' → '}
-                {(flight.onBlockTime || flight.arrivalTime)
-                  ? (flight.onBlockTime || flight.arrivalTime)!.slice(0, 5)
-                  : '—'}
+            {(offBlock || onBlock) && (
+              <span className="font-mono tabular-nums">
+                · {offBlock || '—'} → {onBlock || '—'}
               </span>
             )}
           </p>
         </div>
-        <span className="badge-info font-semibold">
+        <span className="badge-info font-semibold shrink-0">
           {fmtDuration(flight.totalTime)}
         </span>
       </div>
@@ -54,7 +56,7 @@ export default function FlightCard({ flight, onEdit, onDelete, onClick }: Flight
       <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
         <div>
           <span className="text-slate-500 dark:text-slate-400">{t('fields.aircraftReg')}:</span>{' '}
-          <span className="font-medium text-slate-700 dark:text-slate-200">{flight.aircraftReg}</span>
+          <span className="font-medium font-mono tabular-nums text-slate-700 dark:text-slate-200">{flight.aircraftReg}</span>
         </div>
         <div>
           <span className="text-slate-500 dark:text-slate-400">{t('fields.aircraftType')}:</span>{' '}
@@ -86,8 +88,10 @@ export default function FlightCard({ flight, onEdit, onDelete, onClick }: Flight
           </div>
         )}
         {totalLandings > 0 && (
-          <div className="text-slate-600 dark:text-slate-300">
-            <span className="text-slate-500 dark:text-slate-400">{t('fields.landings')}:</span> <span className="font-mono tabular-nums">{flight.landingsDay}D / {flight.landingsNight}N</span>
+          <div className="text-slate-600 dark:text-slate-300 inline-flex items-center gap-1">
+            <PlaneLanding className="w-3.5 h-3.5 text-slate-400" aria-hidden="true" />
+            <span className="text-slate-500 dark:text-slate-400">{t('fields.landings')}:</span>
+            <span className="font-mono tabular-nums">{flight.landingsDay}D / {flight.landingsNight}N</span>
           </div>
         )}
       </div>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from 'react-i18next';
 import { useLogout } from '../../hooks/useAuth';
 import { useAuthStore } from '../../stores/authStore';
 import AnnouncementBanner from '../ui/AnnouncementBanner';
+import { LogoMark } from '../ui/Logo';
+import { ThemeSwitcher } from '../ui/ThemeSwitcher';
 import { APP_NAME } from '../../lib/config';
 
 export default function Layout() {
@@ -37,48 +39,70 @@ export default function Layout() {
       </a>
 
       {/* ── App Header ── */}
-      <header className="fixed top-0 inset-x-0 h-14 lg:h-16 bg-white dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800 z-[1010] flex items-center justify-between px-4 lg:px-6" role="banner">
-        <Link to="/dashboard" className="flex items-center gap-2">
-          <Plane className="w-5 h-5 text-brand-600" aria-hidden="true" />
-          <span className="text-lg font-bold text-brand-800 dark:text-blue-400">{APP_NAME}</span>
+      <header
+        className="fixed top-0 inset-x-0 h-14 lg:h-16 surface-glass border-b z-[1010] flex items-center justify-between px-4 lg:px-6 pt-safe-top tap-none"
+        role="banner"
+      >
+        <Link to="/dashboard" className="flex items-center gap-2.5 group" aria-label={APP_NAME}>
+          <LogoMark size={32} decorative className="drop-shadow-sm transition-transform group-hover:scale-[1.04] group-active:scale-95" />
+          <span className="text-lg font-bold tracking-tight text-gradient-brand">{APP_NAME}</span>
         </Link>
 
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-1 sm:gap-2">
+          <ThemeSwitcher className="hidden sm:flex" />
           {/* User avatar */}
           <button
             onClick={() => navigate('/profile')}
-            className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors"
+            className="flex items-center gap-2 px-1.5 sm:px-2 h-11 rounded-full text-sm text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors tap-none"
             aria-label={t('common:profileAlt')}
           >
-            <span className="hidden sm:inline">{user?.name || user?.email}</span>
-            <span className="w-9 h-9 min-w-[44px] min-h-[44px] rounded-full bg-brand-800 text-white flex items-center justify-center text-xs font-medium">
+            <span className="hidden sm:inline max-w-[160px] truncate">{user?.name || user?.email}</span>
+            <span className="w-9 h-9 rounded-full gradient-brand text-white flex items-center justify-center text-xs font-semibold ring-2 ring-white/60 dark:ring-slate-800 shadow-sm">
               {initials}
             </span>
           </button>
           <button
             onClick={handleLogout}
-            className="btn-ghost btn-sm min-h-[44px] text-slate-500 hover:text-red-600 dark:text-slate-400"
+            className="hidden lg:inline-flex btn-ghost btn-sm min-h-[44px] text-slate-500 hover:text-red-600 dark:text-slate-400"
           >
+            <LogOut className="w-4 h-4" aria-hidden="true" />
             {t('common:logout')}
           </button>
         </div>
       </header>
 
       {/* ── Desktop Sidebar ── */}
-      <aside className="fixed left-0 top-16 bottom-0 w-64 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-800 p-4 hidden lg:flex lg:flex-col z-30" aria-label="Desktop navigation">
-        <nav className="flex-1 space-y-1" aria-label="Main">
+      <aside
+        className="fixed left-0 top-16 bottom-0 w-64 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-800 hidden lg:flex lg:flex-col z-30"
+        aria-label="Desktop navigation"
+      >
+        <div className="p-4">
+          <Link
+            to="/flights"
+            state={{ openForm: true }}
+            className="btn-primary w-full justify-center hover-lift"
+          >
+            <Plus className="w-4 h-4" aria-hidden="true" />
+            {t('nav:addFlight')}
+          </Link>
+        </div>
+        <nav className="flex-1 overflow-y-auto px-3 pb-3 space-y-0.5" aria-label="Main">
           <SidebarItem to="/dashboard" label={t('nav:dashboard')} icon={<LayoutDashboard className="w-5 h-5" />} />
           <SidebarItem to="/flights" label={t('nav:flights')} icon={<Plane className="w-5 h-5" />} />
           <SidebarItem to="/aircraft" label={t('nav:aircraft')} icon={<PlaneTakeoff className="w-5 h-5" />} />
           <SidebarItem to="/currency" label={t('nav:currency')} icon={<Shield className="w-5 h-5" />} />
+
+          <SidebarGroup label={t('nav:licenses')} />
           <SidebarItem to="/licenses" label={t('nav:licenses')} icon={<Award className="w-5 h-5" />} />
           <SidebarItem to="/credentials" label={t('nav:credentials')} icon={<FileText className="w-5 h-5" />} />
+
+          <SidebarGroup label={t('nav:reports')} />
           <SidebarItem to="/reports" label={t('nav:reports')} icon={<BarChart3 className="w-5 h-5" />} />
           <SidebarItem to="/map" label={t('nav:map')} icon={<Map className="w-5 h-5" />} />
           <SidebarItem to="/import" label={t('nav:import')} icon={<Upload className="w-5 h-5" />} />
           <SidebarItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} />
         </nav>
-        <div className="border-t border-slate-200 dark:border-slate-700 pt-4 space-y-1">
+        <div className="border-t border-slate-200 dark:border-slate-800 p-3 space-y-0.5">
           {user?.isAdmin && (
             <SidebarItem to="/admin" label={t('nav:admin')} icon={<ShieldCheck className="w-5 h-5" />} />
           )}
@@ -94,24 +118,28 @@ export default function Layout() {
       </main>
 
       {/* ── Mobile Bottom Nav ── */}
-      <nav className="fixed bottom-0 inset-x-0 bg-white dark:bg-slate-900 border-t border-slate-200 dark:border-slate-800 z-[1010] lg:hidden" aria-label="Mobile navigation" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
+      <nav
+        className="fixed bottom-0 inset-x-0 surface-glass border-t z-[1010] lg:hidden tap-none"
+        aria-label="Mobile navigation"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
         <div className="h-14 flex items-center justify-around">
         <BottomNavItem to="/dashboard" label={t('nav:home')} icon={<LayoutDashboard className="w-5 h-5" />} />
         <BottomNavItem to="/flights" label={t('nav:flights')} icon={<Plane className="w-5 h-5" />} />
         <Link
           to="/flights"
           state={{ openForm: true }}
-          className="flex flex-col items-center justify-center -mt-3"
+          className="flex flex-col items-center justify-center -mt-6 active:scale-95 transition-transform tap-none"
           aria-label={t('nav:addFlight')}
         >
-          <span className="w-12 h-12 bg-blue-600 text-white rounded-full flex items-center justify-center shadow-lg hover:bg-blue-700 transition-colors">
+          <span className="w-14 h-14 gradient-brand text-white rounded-full flex items-center justify-center shadow-lg ring-4 ring-white dark:ring-slate-900">
             <Plus className="w-6 h-6" />
           </span>
         </Link>
         <BottomNavItem to="/reports" label={t('nav:reports')} icon={<BarChart3 className="w-5 h-5" />} />
         <button
           onClick={() => setShowMoreMenu(true)}
-          className="flex flex-col items-center justify-center min-w-[44px] min-h-[44px] text-xs text-slate-400 dark:text-slate-500 transition-colors"
+          className="flex flex-col items-center justify-center min-w-[44px] min-h-[44px] text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors tap-none"
           aria-label="More menu"
         >
           <Menu className="w-5 h-5 mb-0.5" />
@@ -166,10 +194,10 @@ function SidebarItem({ to, label, icon }: { to: string; label: string; icon: Rea
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+        `relative flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors tap-none ${
           isActive
-            ? 'bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400'
-            : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800'
+            ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/25 dark:text-blue-300 nav-active-rail'
+            : 'text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-slate-200'
         }`
       }
     >
@@ -179,20 +207,38 @@ function SidebarItem({ to, label, icon }: { to: string; label: string; icon: Rea
   );
 }
 
+function SidebarGroup({ label }: { label: string }) {
+  return (
+    <div className="px-3 pt-4 pb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+      {label}
+    </div>
+  );
+}
+
 function BottomNavItem({ to, label, icon }: { to: string; label: string; icon: React.ReactNode }) {
   return (
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex flex-col items-center justify-center min-w-[44px] min-h-[44px] text-xs transition-colors ${
+        `relative flex flex-col items-center justify-center min-w-[44px] min-h-[44px] px-3 text-xs font-medium transition-colors tap-none ${
           isActive
             ? 'text-blue-600 dark:text-blue-400'
-            : 'text-slate-400 dark:text-slate-500'
+            : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
         }`
       }
     >
-      <span className="mb-0.5" aria-hidden="true">{icon}</span>
-      <span>{label}</span>
+      {({ isActive }) => (
+        <>
+          <span
+            className={`absolute top-1 h-1 w-6 rounded-full transition-opacity ${
+              isActive ? 'opacity-100 bg-blue-600 dark:bg-blue-400' : 'opacity-0'
+            }`}
+            aria-hidden="true"
+          />
+          <span className="mt-1 mb-0.5" aria-hidden="true">{icon}</span>
+          <span>{label}</span>
+        </>
+      )}
     </NavLink>
   );
 }

--- a/src/components/ui/Logo.tsx
+++ b/src/components/ui/Logo.tsx
@@ -1,0 +1,80 @@
+import { cn } from '../../lib/cn';
+
+/**
+ * NinerLog brandmark — wing + horizon over an aviation-blue gradient badge.
+ *
+ * Use <LogoMark/> for icon-only contexts (favicons, headers at small sizes,
+ * loaders) and <Logo/> when you want the wordmark next to the mark.
+ */
+
+interface LogoMarkProps {
+  className?: string;
+  /** Pixel size; default 32 (matches mobile header height comfortably). */
+  size?: number;
+  /** Hide from screen readers (when paired with a wordmark). */
+  decorative?: boolean;
+}
+
+export function LogoMark({ className, size = 32, decorative = false }: LogoMarkProps) {
+  const a11y = decorative
+    ? { 'aria-hidden': true as const, focusable: false as const }
+    : { role: 'img' as const, 'aria-label': 'NinerLog' };
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      width={size}
+      height={size}
+      className={cn('shrink-0', className)}
+      {...a11y}
+    >
+      <defs>
+        <linearGradient id="nl-mark-bg" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#1E3A5F" />
+          <stop offset="55%" stopColor="#1D4ED8" />
+          <stop offset="100%" stopColor="#2563EB" />
+        </linearGradient>
+        <linearGradient id="nl-mark-shine" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#FFFFFF" stopOpacity="0.18" />
+          <stop offset="55%" stopColor="#FFFFFF" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <rect x="0" y="0" width="512" height="512" rx="112" ry="112" fill="url(#nl-mark-bg)" />
+      <rect x="0" y="0" width="512" height="512" rx="112" ry="112" fill="url(#nl-mark-shine)" />
+      <rect x="80" y="320" width="352" height="10" rx="5" fill="#FFFFFF" opacity="0.55" />
+      <path d="M96 280 L256 144 L416 280 L376 280 L256 196 L136 280 Z" fill="#FFFFFF" />
+      <path d="M196 256 L256 212 L316 256 L292 256 L256 232 L220 256 Z" fill="#FFFFFF" opacity="0.55" />
+      <circle cx="256" cy="372" r="10" fill="#FFFFFF" opacity="0.85" />
+    </svg>
+  );
+}
+
+interface LogoProps {
+  className?: string;
+  /** Pixel size of the mark; the wordmark scales with it. */
+  size?: number;
+  wordmark?: string;
+  /** Visual emphasis. `hero` is for splash/login, `inline` for headers. */
+  variant?: 'inline' | 'hero';
+}
+
+export function Logo({
+  className,
+  size = 32,
+  wordmark = 'NinerLog',
+  variant = 'inline',
+}: LogoProps) {
+  return (
+    <span className={cn('inline-flex items-center gap-2', className)}>
+      <LogoMark size={size} decorative />
+      <span
+        className={cn(
+          'font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-br from-brand-800 via-brand-700 to-brand-500 dark:from-blue-300 dark:via-blue-300 dark:to-blue-400',
+          variant === 'hero' ? 'text-3xl sm:text-4xl' : 'text-lg',
+        )}
+      >
+        {wordmark}
+      </span>
+    </span>
+  );
+}

--- a/src/components/ui/StatCard.tsx
+++ b/src/components/ui/StatCard.tsx
@@ -6,21 +6,38 @@ interface StatCardProps {
   unit?: string;
   detail?: string;
   icon?: React.ReactNode;
+  /** Subtle accent color for the icon halo. */
+  accent?: 'blue' | 'green' | 'amber' | 'red' | 'slate';
   className?: string;
 }
 
-export function StatCard({ label, value, unit, detail, icon, className }: StatCardProps) {
+const ACCENT: Record<NonNullable<StatCardProps['accent']>, string> = {
+  blue: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300',
+  green: 'bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-300',
+  amber: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-300',
+  red: 'bg-red-50 text-red-600 dark:bg-red-900/30 dark:text-red-300',
+  slate: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+};
+
+export function StatCard({ label, value, unit, detail, icon, accent = 'slate', className }: StatCardProps) {
   return (
-    <div className={cn('card', className)}>
-      <div className="flex items-center gap-2 mb-1">
-        {icon && <span className="text-slate-400 dark:text-slate-500" aria-hidden="true">{icon}</span>}
+    <div className={cn('card hover-lift', className)}>
+      <div className="flex items-center gap-2 mb-2">
+        {icon && (
+          <span
+            className={cn('inline-flex items-center justify-center w-7 h-7 rounded-lg', ACCENT[accent])}
+            aria-hidden="true"
+          >
+            {icon}
+          </span>
+        )}
         <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{label}</p>
       </div>
-      <p className="data-lg text-slate-800 dark:text-slate-100">
+      <p className="data-lg text-slate-800 dark:text-slate-100 leading-none">
         {value}
         {unit && <span className="text-sm font-normal text-slate-500 dark:text-slate-400 ml-1">{unit}</span>}
       </p>
-      {detail && <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">{detail}</p>}
+      {detail && <p className="text-xs text-slate-400 dark:text-slate-500 mt-2">{detail}</p>}
     </div>
   );
 }

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -4,3 +4,4 @@ export { ConfirmDialog } from './ConfirmDialog';
 export { Skeleton, SkeletonCard, SkeletonList, SkeletonGrid } from './Skeleton';
 export { ErrorState } from './ErrorState';
 export { PageWrapper, PageHeader } from './PageWrapper';
+export { Logo, LogoMark } from './Logo';

--- a/src/index.css
+++ b/src/index.css
@@ -294,4 +294,90 @@
   .data-sm {
     @apply text-sm font-medium font-mono tabular-nums;
   }
+
+  /* ── Polish: hover-lift for interactive cards ── */
+  .hover-lift {
+    @apply transition-[transform,box-shadow] duration-200 ease-out;
+  }
+  .hover-lift:hover {
+    @apply -translate-y-0.5 shadow-md;
+  }
+  .hover-lift:active {
+    @apply translate-y-0 shadow-sm;
+  }
+
+  /* ── Polish: glass / frosted surface (mobile nav, headers) ── */
+  .surface-glass {
+    @apply bg-white/80 dark:bg-slate-900/75 backdrop-blur-md backdrop-saturate-150;
+    @apply border-slate-200/70 dark:border-slate-800/70;
+  }
+  /* Fallback when backdrop-filter is unsupported */
+  @supports not ((backdrop-filter: blur(12px)) or (-webkit-backdrop-filter: blur(12px))) {
+    .surface-glass {
+      @apply bg-white dark:bg-slate-900;
+    }
+  }
+
+  /* ── Polish: brand gradient surfaces ── */
+  .gradient-brand {
+    background-image: linear-gradient(135deg, #1E3A5F 0%, #1D4ED8 55%, #2563EB 100%);
+  }
+  .gradient-brand-soft {
+    @apply bg-gradient-to-br from-brand-50 via-white to-blue-50;
+    @apply dark:from-slate-800 dark:via-slate-800/70 dark:to-blue-950/40;
+  }
+
+  /* ── Polish: hero greeting card ── */
+  .hero-greeting {
+    @apply relative overflow-hidden rounded-xl p-5 sm:p-6 text-white shadow-md;
+    background-image:
+      radial-gradient(ellipse at top right, rgba(96,165,250,0.45), transparent 55%),
+      linear-gradient(135deg, #1E3A5F 0%, #1D4ED8 60%, #2563EB 100%);
+  }
+  .hero-greeting::after {
+    content: '';
+    position: absolute; inset: 0;
+    background: linear-gradient(180deg, rgba(255,255,255,0.10), rgba(255,255,255,0));
+    pointer-events: none;
+  }
+
+  /* ── Polish: text gradient (for wordmark / accents) ── */
+  .text-gradient-brand {
+    @apply bg-clip-text text-transparent;
+    background-image: linear-gradient(135deg, #1E3A5F 0%, #1D4ED8 60%, #2563EB 100%);
+  }
+  .dark .text-gradient-brand {
+    background-image: linear-gradient(135deg, #93C5FD 0%, #60A5FA 60%, #3B82F6 100%);
+  }
+
+  /* ── Polish: sidebar/nav active accent ── */
+  .nav-active-rail {
+    @apply relative;
+  }
+  .nav-active-rail::before {
+    content: '';
+    @apply absolute left-0 top-1.5 bottom-1.5 w-1 rounded-r-full bg-blue-600 dark:bg-blue-400;
+  }
+
+  /* ── Polish: status ring for currency / health badges ── */
+  .ring-status-current  { @apply ring-2 ring-green-500/30 dark:ring-green-400/30; }
+  .ring-status-expiring { @apply ring-2 ring-amber-500/30 dark:ring-amber-400/30; }
+  .ring-status-expired  { @apply ring-2 ring-red-500/30 dark:ring-red-400/30; }
+}
+
+@layer utilities {
+  /* iOS-style safe-area helpers */
+  .pt-safe-top {
+    padding-top: env(safe-area-inset-top);
+  }
+  .pl-safe-left {
+    padding-left: env(safe-area-inset-left);
+  }
+  .pr-safe-right {
+    padding-right: env(safe-area-inset-right);
+  }
+  /* Tap-highlight removal (mobile feels app-native) */
+  .tap-none {
+    -webkit-tap-highlight-color: transparent;
+  }
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Clock, Plane, ArrowDownToLine, BadgeCheck } from 'lucide-react';
 import { useAuthStore } from '../stores/authStore';
 import { useFlights } from '../hooks/useFlights';
 import { useMyStatistics } from '../hooks/useStatistics';
@@ -37,15 +38,24 @@ export default function DashboardPage() {
 
   return (
     <div className="mx-auto max-w-[1280px] py-6">
-      {/* Page header */}
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="page-title">{greeting}, {user?.name || user?.email}!</h1>
-        <button
-          onClick={() => navigate('/flights', { state: { openForm: true } })}
-          className="btn-primary hidden sm:inline-flex"
-        >
-          {t('dashboard:logFlight')}
-        </button>
+      {/* Hero greeting */}
+      <div className="hero-greeting mb-6">
+        <div className="relative flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-wider text-blue-100/80">
+              {greeting}
+            </p>
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight text-white mt-1">
+              {user?.name || user?.email}
+            </h1>
+          </div>
+          <button
+            onClick={() => navigate('/flights', { state: { openForm: true } })}
+            className="hidden sm:inline-flex items-center justify-center gap-2 h-11 px-5 rounded-md bg-white text-blue-700 font-semibold shadow-sm hover:bg-blue-50 active:scale-[0.98] transition-all"
+          >
+            {t('dashboard:logFlight')}
+          </button>
+        </div>
       </div>
 
       {/* Currency Status — per class rating */}
@@ -102,13 +112,30 @@ export default function DashboardPage() {
 
       {/* Stats grid */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4 mb-6">
-        <StatCard label={t('dashboard:stats.totalTime')} value={statistics ? fmtDuration(statistics.totalMinutes) : '0h 0m'} />
-        <StatCard label={t('dashboard:stats.picTime')} value={statistics ? fmtDuration(statistics.picMinutes) : '0h 0m'} />
-        <StatCard label={t('dashboard:stats.totalFlights')} value={String(statistics?.totalFlights ?? totalFlights)} />
+        <StatCard
+          label={t('dashboard:stats.totalTime')}
+          value={statistics ? fmtDuration(statistics.totalMinutes) : '0h 0m'}
+          icon={<Clock className="w-4 h-4" />}
+          accent="blue"
+        />
+        <StatCard
+          label={t('dashboard:stats.picTime')}
+          value={statistics ? fmtDuration(statistics.picMinutes) : '0h 0m'}
+          icon={<BadgeCheck className="w-4 h-4" />}
+          accent="green"
+        />
+        <StatCard
+          label={t('dashboard:stats.totalFlights')}
+          value={String(statistics?.totalFlights ?? totalFlights)}
+          icon={<Plane className="w-4 h-4" />}
+          accent="blue"
+        />
         <StatCard
           label={t('dashboard:stats.landings')}
           value={String((statistics?.landingsDay ?? 0) + (statistics?.landingsNight ?? 0))}
           detail={`${statistics?.landingsDay ?? 0} ${t('dashboard:stats.day')} / ${statistics?.landingsNight ?? 0} ${t('dashboard:stats.night')}`}
+          icon={<ArrowDownToLine className="w-4 h-4" />}
+          accent="amber"
         />
       </div>
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -9,6 +9,7 @@ import { useLogin2FA } from '../../hooks/useTwoFactor';
 import { useAuthStore } from '../../stores/authStore';
 import i18n from '../../i18n';
 import { APP_NAME } from '../../lib/config';
+import { LogoMark } from '../../components/ui/Logo';
 
 const loginSchema = z.object({
   email: z.string().email('Invalid email address'),
@@ -82,13 +83,24 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-900 px-4">
-      <div className="w-full max-w-[400px] space-y-8">
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden bg-slate-50 dark:bg-slate-900 px-4 py-10">
+      {/* Aviation atmosphere — subtle radial brand glow, hidden in reduced-motion is fine because static */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'radial-gradient(60rem 36rem at 50% -10%, rgba(37,99,235,0.18), transparent 60%), radial-gradient(40rem 28rem at 100% 110%, rgba(30,58,95,0.20), transparent 60%)',
+        }}
+      />
+      <div className="relative w-full max-w-[400px] space-y-6">
         {/* Logo & Tagline */}
         <div className="text-center">
-          <div className="text-4xl mb-2">✈</div>
-          <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-100">{APP_NAME}</h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          <div className="inline-flex items-center justify-center mb-3">
+            <LogoMark size={64} className="drop-shadow-md" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-gradient-brand">{APP_NAME}</h1>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
             {t('auth:login.tagline')}
           </p>
         </div>

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useRegister } from '../../hooks/useAuth';
 import { APP_NAME } from '../../lib/config';
+import { LogoMark } from '../../components/ui/Logo';
 import { extractApiError, extractApiStatus } from '../../lib/errors';
 
 const registerSchema = z
@@ -56,13 +57,23 @@ export default function RegisterPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-900 px-4 py-8">
-      <div className="w-full max-w-[400px] space-y-8">
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden bg-slate-50 dark:bg-slate-900 px-4 py-10">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'radial-gradient(60rem 36rem at 50% -10%, rgba(37,99,235,0.18), transparent 60%), radial-gradient(40rem 28rem at 100% 110%, rgba(30,58,95,0.20), transparent 60%)',
+        }}
+      />
+      <div className="relative w-full max-w-[400px] space-y-6">
         {/* Logo & Tagline */}
         <div className="text-center">
-          <div className="text-4xl mb-2">✈</div>
-          <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-100">{APP_NAME}</h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          <div className="inline-flex items-center justify-center mb-3">
+            <LogoMark size={64} className="drop-shadow-md" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-gradient-brand">{APP_NAME}</h1>
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
             {t('auth:register.tagline')}
           </p>
         </div>


### PR DESCRIPTION
## Summary

Aligns the app with the NinerLog design system from `ninerlog-project/docs/design/` and brings the desktop UI in line with the mobile/PWA polish so the experience is **field-usable on a phone or iPad** in cockpit and tarmac conditions.

## What changed

### Brand & assets
- New brandmark (`public/logo.svg`, `favicon.svg`, `apple-touch-icon.svg`) — gradient aviation-blue badge, white wing chevron, horizon line, altitude dot
- `Logo` / `LogoMark` React component with inline-SVG gradient mark and wordmark variants

### Design-system utilities (`src/index.css`)
- `.hover-lift`, `.surface-glass` (backdrop-blur with `@supports not` fallback)
- `.gradient-brand`, `.gradient-brand-soft`, `.text-gradient-brand`
- `.hero-greeting` (radial + linear gradient with subtle ::after sheen)
- `.nav-active-rail` (4px left rail), `.ring-status-current/expiring/expired`
- iOS safe-area utilities (`pt-safe-top`, `pl-safe-left`, `pr-safe-right`) and `.tap-none`

### Layout
- Glass header with gradient wordmark and gradient-ring avatar
- Glass bottom nav with 56px gradient FAB (halo ring), animated top-pill active indicator
- Desktop sidebar: primary "Log Flight" CTA, section group dividers, active-rail nav items

### Components
- **StatCard** — `accent` prop (blue/green/amber/red/slate) with colored icon halos, `hover-lift`
- **CurrencyCard** — Lucide `Shield…` icons by status, status-tinted gradient surface, animated progress bars, calendar icon on expiry footer
- **FlightCard** — route hero with `PlaneTakeoff` halo, calendar / `PlaneLanding` icons

### Pages
- **Login / Register** — hero `LogoMark` + atmospheric radial glow background
- **Dashboard** — `.hero-greeting` card with time-of-day greeting, name and "Log Flight" CTA. Total time + flight count moved out of the hero (they already live in the StatCards below, so the hero no longer duplicates dashboard data)

### PWA chrome (`index.html`)
- `apple-touch-icon`, `mask-icon`, dual `theme-color` (light/dark), `color-scheme: light dark`
- `apple-mobile-web-app-capable`, `mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style: black-translucent`, `apple-mobile-web-app-title: NinerLog`

## Validation

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| Vitest unit tests | **256 / 256 pass** |
| Playwright e2e (Docker, full Chromium suite) | **76 / 79 pass** |

The 3 remaining e2e failures are **pre-existing regressions unrelated to this PR** in `profile-help.spec.ts` (Time Display Preference). They were caused by commit `000d1a9` ("fix: replace profile settings with dropdowns…") changing `<button>`s to a `<select>` without updating the tests. Tracked in #28 — per the workflow rules these are documented as a regression issue rather than worked around in tests.

## Screens affected

Login · Register · Dashboard · Header · Bottom nav · Sidebar · Currency cards · Flight cards · Stat cards · Favicon / installed PWA chrome.
