### PR TITLE
feat(auth/pwa): durable session for installed PWAs — no more daily 2FA

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from './stores/authStore';
 import { useTheme } from './hooks/useTheme';
+import { bootstrapPromise } from './api/client';
 import Layout from './components/layout/Layout';
 
 // Lazy-loaded pages for code splitting
@@ -34,9 +35,23 @@ function PageLoader() {
 
 function App() {
   const { isAuthenticated } = useAuthStore();
+  const [bootReady, setBootReady] = useState(() => !bootstrapPromise);
 
   // Sync theme preference to document
   useTheme();
+
+  // Wait for the in-flight bootstrap refresh before rendering protected routes,
+  // so cold launches of the installed PWA never flash to /login on iOS.
+  useEffect(() => {
+    if (bootReady) return;
+    let cancelled = false;
+    bootstrapPromise?.finally(() => {
+      if (!cancelled) setBootReady(true);
+    });
+    return () => { cancelled = true; };
+  }, [bootReady]);
+
+  if (!bootReady) return <PageLoader />;
 
   return (
     <Suspense fallback={<PageLoader />}>

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -44,7 +44,12 @@ async function refreshAccessToken(): Promise<boolean> {
 
 // Add auth token interceptor
 apiClient.use({
-  onRequest({ request }) {
+  async onRequest({ request }) {
+    // Wait for the in-flight bootstrap refresh (if any) so the very first wave
+    // of requests after a cold launch carries a valid Authorization header.
+    if (bootstrapPromise) {
+      try { await bootstrapPromise; } catch { /* ignore — onResponse will handle 401 */ }
+    }
     const token = useAuthStore.getState().accessToken;
     if (token) {
       request.headers.set('Authorization', `Bearer ${token}`);
@@ -52,24 +57,44 @@ apiClient.use({
     return request;
   },
   async onResponse({ response, request }) {
-    // Handle 401 by attempting token refresh — but NOT for auth-related endpoints
-    if (response.status === 401) {
-      const url = request.url || '';
-      const isAuthEndpoint = url.includes('/auth/login') || url.includes('/auth/2fa/') || url.includes('/auth/register') || url.includes('/auth/refresh') || url.includes('/auth/password-reset');
-      if (!isAuthEndpoint) {
-        // Attempt to refresh the token
-        if (!refreshPromise) {
-          refreshPromise = refreshAccessToken().finally(() => {
-            refreshPromise = null;
-          });
-        }
-        const success = await refreshPromise;
-        if (!success && typeof window !== 'undefined') {
-          window.location.href = '/login';
-        }
-      }
+    // Handle 401 by refreshing the token AND retrying the original request once
+    if (response.status !== 401) return response;
+
+    const url = request.url || '';
+    const isAuthEndpoint =
+      url.includes('/auth/login') ||
+      url.includes('/auth/2fa/') ||
+      url.includes('/auth/register') ||
+      url.includes('/auth/refresh') ||
+      url.includes('/auth/password-reset');
+    if (isAuthEndpoint) return response;
+
+    // Avoid infinite loops: only retry once per request
+    if ((request as Request & { __retried?: boolean }).__retried) return response;
+
+    if (!refreshPromise) {
+      refreshPromise = refreshAccessToken().finally(() => {
+        refreshPromise = null;
+      });
     }
-    return response;
+    const success = await refreshPromise;
+    if (!success) {
+      if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+        window.location.href = '/login';
+      }
+      return response;
+    }
+
+    // Re-issue the original request with the new access token
+    const newToken = useAuthStore.getState().accessToken;
+    const retryRequest = request.clone();
+    if (newToken) retryRequest.headers.set('Authorization', `Bearer ${newToken}`);
+    (retryRequest as Request & { __retried?: boolean }).__retried = true;
+    try {
+      return await fetch(retryRequest);
+    } catch {
+      return response;
+    }
   },
 });
 
@@ -120,18 +145,53 @@ useAuthStore.subscribe((state, prevState) => {
 // case where the store is populated before the subscription fires)
 scheduleTokenRefresh();
 
-// ── Bootstrap refresh on page reload ──
-// After rehydration, if we have a refreshToken but no accessToken, immediately
-// fetch a new access token so the user doesn't get logged out on reload.
-{
-  const { refreshToken, accessToken, isAuthenticated } = useAuthStore.getState();
-  if (isAuthenticated && refreshToken && !accessToken) {
-    refreshAccessToken().then((success) => {
-      if (success) {
-        scheduleTokenRefresh();
-      }
-    });
+// ── Bootstrap refresh on app start ──
+// Resolves once the session is "ready" (either we have a fresh access token or
+// we've decided we don't). All API requests await this on first call, so the
+// initial wave never goes out unauthenticated when the PWA cold-launches from
+// the iOS / Android home screen.
+export let bootstrapPromise: Promise<boolean> | null = null;
+
+function bootstrap(): Promise<boolean> {
+  const { refreshToken, accessToken, tokenExpiresAt, isAuthenticated } = useAuthStore.getState();
+  if (!isAuthenticated || !refreshToken) return Promise.resolve(false);
+
+  // If the persisted access token is still valid, use it as-is.
+  // The proactive timer will refresh it before expiry.
+  const skewMs = 30_000; // refresh slightly early to avoid clock-skew 401s
+  if (accessToken && tokenExpiresAt && tokenExpiresAt - Date.now() > skewMs) {
+    scheduleTokenRefresh();
+    return Promise.resolve(true);
   }
+
+  return refreshAccessToken().then((ok) => {
+    if (ok) scheduleTokenRefresh();
+    return ok;
+  });
+}
+
+bootstrapPromise = bootstrap().finally(() => {
+  // Keep awaitable but allow GC of result; subsequent awaits resolve immediately.
+});
+
+// ── Resume on visibility / online ──
+// When the user re-opens the installed PWA from the home screen, refresh the
+// token if it's stale so the first interaction never sees a 401.
+if (typeof window !== 'undefined') {
+  const refreshIfStale = () => {
+    const { isAuthenticated, refreshToken, tokenExpiresAt } = useAuthStore.getState();
+    if (!isAuthenticated || !refreshToken) return;
+    const stale = !tokenExpiresAt || tokenExpiresAt - Date.now() < 60_000;
+    if (!stale) return;
+    if (refreshPromise) return; // already refreshing
+    refreshPromise = refreshAccessToken().finally(() => { refreshPromise = null; });
+    refreshPromise.then((ok) => { if (ok) scheduleTokenRefresh(); });
+  };
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') refreshIfStale();
+  });
+  window.addEventListener('online', refreshIfStale);
+  window.addEventListener('pageshow', refreshIfStale); // bfcache / iOS swipe-back
 }
 
 // Export types for convenience

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -60,12 +60,19 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
-      // Persist user profile, auth flag, and refresh token (for session continuity across reloads).
-      // Access token stays in memory only (short-lived, 15 min).
+      // Persist full session so an installed PWA (iOS home-screen / Android) can
+      // resume instantly without a /auth/refresh round-trip on every cold launch.
+      // Trade-off: the access token is reachable from JS, so an XSS on this origin
+      // could exfiltrate it — same blast radius as making authenticated calls
+      // directly. The proper hardening is HttpOnly refresh-cookie auth (tracked
+      // separately in the API spec); until then, durable session > daily 2FA pain.
       partialize: (state) => ({
         user: state.user,
         isAuthenticated: state.isAuthenticated,
         refreshToken: state.refreshToken,
+        accessToken: state.accessToken,
+        tokenExpiresAt: state.tokenExpiresAt,
+        expiresIn: state.expiresIn,
       }),
     }
   )

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,25 +11,38 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'mask-icon.svg'],
+      includeAssets: ['favicon.svg', 'apple-touch-icon.svg', 'logo.svg'],
+      workbox: {
+        // Don't cache API calls — the app must always hit the live API for auth
+        // and data freshness. Caching /api/* would break session resume on iOS.
+        navigateFallbackDenylist: [/^\/api\//],
+        runtimeCaching: [
+          {
+            urlPattern: /^\/api\//,
+            handler: 'NetworkOnly',
+          },
+        ],
+      },
       manifest: {
         name: 'NinerLog',
         short_name: 'NinerLog',
         description: 'EASA/FAA Compliant Pilot Logbook',
-        theme_color: '#2563eb',
+        id: '/',
+        scope: '/',
+        start_url: '/dashboard',
+        display: 'standalone',
+        display_override: ['standalone', 'minimal-ui'],
+        orientation: 'any',
+        theme_color: '#1E3A5F',
+        background_color: '#0f172a',
+        categories: ['productivity', 'utilities', 'travel'],
         icons: [
-          {
-            src: 'pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png'
-          },
-          {
-            src: 'pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          }
-        ]
-      }
+          { src: 'favicon.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any' },
+          { src: 'logo.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'any' },
+          { src: 'apple-touch-icon.svg', sizes: '180x180', type: 'image/svg+xml', purpose: 'any' },
+          { src: 'logo.svg', sizes: 'any', type: 'image/svg+xml', purpose: 'maskable' },
+        ],
+      },
     }),
     // Bundle size visualization — generates dist/stats.html on build
     process.env.ANALYZE && visualizer({


### PR DESCRIPTION
## Why

Installed PWA on iOS home-screen logged out on every cold launch and prompted for password + 2FA. Three real bugs caused this:

1. **The 401 interceptor refreshed the token but never retried the original request**, so the first wave of calls after a cold launch surfaced as errors and could trigger redirect-to-login flicker.
2. **`App.tsx` rendered protected routes immediately** while the bootstrap refresh was still in flight, so the initial requests went out unauthenticated.
3. **The access token was memory-only** — every iOS PWA cold launch forced a `/auth/refresh` round-trip; if the refresh token had rotated/expired between sessions the user was bounced to login + 2FA.

## Changes

### Auth & session
- `authStore`: persist `accessToken` + `tokenExpiresAt` alongside `refreshToken` so iOS / Android home-screen PWAs **resume instantly** when the token is still valid (15-min window). Trade-off documented in code: HttpOnly refresh-cookie auth is the proper hardening and should be tracked separately on the API side (#).
- `api/client.ts`:
  - `onResponse` now **actually retries the original request** after a successful refresh. Single in-flight refresh deduped via `refreshPromise`; per-request `__retried` flag prevents loops.
  - `onRequest` awaits the in-flight bootstrap so the very first wave of calls always carries a valid `Authorization` header.
  - Bootstrap promise is exported and resolves once the session is either ready or we've decided we don't have one.
  - **Resume-on-foreground**: `visibilitychange` / `online` / `pageshow` listeners refresh the token if stale (<60s to expiry) so re-opening the PWA after lunch never sees a 401.
- `App.tsx`: gate protected-route render on `bootstrapPromise` so cold launches don't flash to `/login`.

### PWA manifest hardening
- `id`, `scope`, `start_url=/dashboard`, `display=standalone` + `display_override`, `orientation`, `background_color`, `theme_color` aligned with `brand-800` (`#1E3A5F`)
- SVG icons (`favicon.svg`, `logo.svg`, `apple-touch-icon.svg`) including a **maskable** variant for adaptive Android icons
- Workbox: `NetworkOnly` for `/api/*` + `navigateFallbackDenylist` so auth + data calls always hit the live API and aren't intercepted by the SW

## Validation

| Check | Result |
| --- | --- |
| `tsc --noEmit` | clean |
| Vitest unit tests | **256 / 256 pass** |

## Not in this PR (tracked separately)

- **Passkeys / WebAuthn (#6)** — needs `/auth/webauthn/*` endpoints in `ninerlog-api/api-spec/openapi.yaml`. Filing an API issue.
- **HttpOnly refresh-token cookie (#5)** — strongest fix for iOS ITP storage purges, but requires same-registrable-domain + CORS coordination with the API. Tracked separately.
