### PR TITLE
fix(i18n): add missing passengerCurrencyDesc translation (#32)

### DIFF
--- a/src/i18n/locales/de/currency.json
+++ b/src/i18n/locales/de/currency.json
@@ -6,6 +6,7 @@
   "alerts_other": "{{count}} Warnungen",
   "ratingCurrency": "Berechtigungs- & Lizenz-Gültigkeit",
   "passengerCurrency": "Passagier-Gültigkeit",
+  "passengerCurrencyDesc": "Erforderliche Landungen, um Passagiere mitnehmen zu dürfen. Alleinflug ist auch ohne Passagier-Gültigkeit möglich.",
   "flightReview": "Flugüberprüfung",
   "noRatings": "Keine Klassenberechtigungen gefunden. Fügen Sie eine Lizenz mit Klassenberechtigungen hinzu.",
   "noCredentials": "Keine Nachweise gefunden. Fügen Sie Medicals und Zertifikate hinzu.",

--- a/src/i18n/locales/en/currency.json
+++ b/src/i18n/locales/en/currency.json
@@ -6,6 +6,7 @@
   "alerts_other": "{{count}} alerts",
   "ratingCurrency": "Rating & License Currency",
   "passengerCurrency": "Passenger Currency",
+  "passengerCurrencyDesc": "Recent landings required to carry passengers. You can still fly solo without passenger currency.",
   "flightReview": "Flight Review",
   "noRatings": "No class ratings found. Add a license with class ratings to see currency status.",
   "noCredentials": "No credentials found. Add medicals and certificates to track validity.",


### PR DESCRIPTION
## Summary

The Currency page rendered the raw key `passengerCurrencyDesc` because the translation entry was missing from the locale files. This adds the key with appropriate copy in English and German.

## Changes
- `src/i18n/locales/en/currency.json`: add `passengerCurrencyDesc`
- `src/i18n/locales/de/currency.json`: add `passengerCurrencyDesc`

## Verification
- Unit tests: `npx vitest run` — 256/256 passed
- E2E tests: Playwright in Docker (`docker compose -f docker-compose.test.yml --profile e2e up`) — 78 passed (1 flaky retried successfully, exit 0)

Fixes #32