### PR TITLE
fix(stats): reload time/landing stats on flight create/update/delete/import (#33)

### DIFF
--- a/src/__tests__/hooks/invalidation.test.ts
+++ b/src/__tests__/hooks/invalidation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import {
+  FLIGHT_DEPENDENT_QUERY_KEYS,
+  invalidateFlightDependentQueries,
+} from '../../hooks/invalidation';
+
+describe('invalidateFlightDependentQueries', () => {
+  it('invalidates every flight-dependent query key', () => {
+    const queryClient = new QueryClient();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    invalidateFlightDependentQueries(queryClient);
+
+    expect(spy).toHaveBeenCalledTimes(FLIGHT_DEPENDENT_QUERY_KEYS.length);
+    for (const key of FLIGHT_DEPENDENT_QUERY_KEYS) {
+      expect(spy).toHaveBeenCalledWith({ queryKey: key });
+    }
+  });
+
+  it('covers dashboard time/landing stats query keys', () => {
+    // Regression guard for ninerlog-frontend#33: stats must reload when
+    // flights are created/updated/deleted/imported.
+    const flatKeys = FLIGHT_DEPENDENT_QUERY_KEYS.map((k) => k[0]);
+    expect(flatKeys).toEqual(
+      expect.arrayContaining([
+        'flights',
+        'statistics',
+        'my-statistics',
+        'currency',
+        'stats',
+        'statsByClass',
+        'trends',
+      ]),
+    );
+  });
+});

--- a/src/hooks/invalidation.ts
+++ b/src/hooks/invalidation.ts
@@ -1,0 +1,25 @@
+import type { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Query keys that depend on the user's flight log and must be refreshed
+ * whenever flights are created, updated, deleted, or imported.
+ */
+export const FLIGHT_DEPENDENT_QUERY_KEYS: readonly (readonly unknown[])[] = [
+  ['flights'],
+  ['statistics'],
+  ['my-statistics'],
+  ['currency'],
+  ['stats'],
+  ['statsByClass'],
+  ['trends'],
+];
+
+/**
+ * Invalidate all queries that depend on the user's flight log.
+ * Call from mutation onSuccess handlers when flights change.
+ */
+export function invalidateFlightDependentQueries(queryClient: QueryClient): void {
+  for (const queryKey of FLIGHT_DEPENDENT_QUERY_KEYS) {
+    queryClient.invalidateQueries({ queryKey: queryKey as unknown[] });
+  }
+}

--- a/src/hooks/useFlights.ts
+++ b/src/hooks/useFlights.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import type { components, operations } from '../api/schema';
+import { invalidateFlightDependentQueries } from './invalidation';
 
 type Flight = components['schemas']['Flight'];
 type FlightCreate = components['schemas']['FlightCreate'];
@@ -50,9 +51,7 @@ export const useCreateFlight = () => {
       return data as Flight;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['flights'] });
-      queryClient.invalidateQueries({ queryKey: ['statistics'] });
-      queryClient.invalidateQueries({ queryKey: ['currency'] });
+      invalidateFlightDependentQueries(queryClient);
     },
   });
 };
@@ -71,10 +70,8 @@ export const useUpdateFlight = () => {
       return data as Flight;
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['flights'] });
+      invalidateFlightDependentQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['flights', data.id] });
-      queryClient.invalidateQueries({ queryKey: ['statistics'] });
-      queryClient.invalidateQueries({ queryKey: ['currency'] });
     },
   });
 };
@@ -91,9 +88,7 @@ export const useDeleteFlight = () => {
       if (error) throw error;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['flights'] });
-      queryClient.invalidateQueries({ queryKey: ['statistics'] });
-      queryClient.invalidateQueries({ queryKey: ['currency'] });
+      invalidateFlightDependentQueries(queryClient);
     },
   });
 };

--- a/src/hooks/useImport.ts
+++ b/src/hooks/useImport.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '../stores/authStore';
 import type { components } from '../api/schema';
+import { invalidateFlightDependentQueries } from './invalidation';
 
 type ImportUploadResponse = components['schemas']['ImportUploadResponse'];
 type ImportPreviewResponse = components['schemas']['ImportPreviewResponse'];
@@ -57,6 +58,7 @@ export const usePreviewImport = () => {
 };
 
 export const useConfirmImport = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (req: {
       uploadToken: string;
@@ -73,6 +75,10 @@ export const useConfirmImport = () => {
         throw new Error(err.error || 'Import failed');
       }
       return res.json();
+    },
+    onSuccess: () => {
+      invalidateFlightDependentQueries(queryClient);
+      queryClient.invalidateQueries({ queryKey: ['imports'] });
     },
   });
 };

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '../api/client';
 import { useAuthStore } from '../stores/authStore';
 import type { components } from '../api/schema';
+import { invalidateFlightDependentQueries } from './invalidation';
 
 type User = components['schemas']['User'];
 
@@ -65,9 +66,7 @@ export const useDeleteAllFlights = () => {
       return data as { deleted: number };
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['flights'] });
-      queryClient.invalidateQueries({ queryKey: ['statistics'] });
-      queryClient.invalidateQueries({ queryKey: ['currency'] });
+      invalidateFlightDependentQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['imports'] });
     },
   });


### PR DESCRIPTION
## Summary

Fixes #33. The dashboard time/landing stats and reports did not refresh after create/update/delete/import of flights because the flight mutations only invalidated the legacy `['statistics']` and `['currency']` query keys, while the dashboard hooks use `['my-statistics', ...]` and `['stats', 'by-class']`, and the reports page uses `['statsByClass']` / `['trends']`.

## Changes

- New `src/hooks/invalidation.ts` exports `FLIGHT_DEPENDENT_QUERY_KEYS` and `invalidateFlightDependentQueries(queryClient)`.
- `useCreateFlight`, `useUpdateFlight`, `useDeleteFlight` (in `useFlights.ts`), `useDeleteAllFlights` (in `useProfile.ts`), and `useConfirmImport` (in `useImport.ts`) all call the helper on success so every flight-dependent view refreshes automatically.
- `useConfirmImport` previously did not invalidate anything; it now invalidates flight-dependent queries plus `['imports']`.
- Added unit test `src/__tests__/hooks/invalidation.test.ts` covering the helper and acting as a regression guard for the dashboard query keys.

## Tests

- `npx vitest run` — 258 / 258 pass (256 existing + 2 new)
- `bash scripts/run-all-tests.sh` (frontend) — 79 / 79 Playwright e2e pass
- `go test ./...` (api) — pass
- `bash scripts/run-e2e-tests.sh` (api) — pass

Closes #33