### PR TITLE
feat(auth): WebAuthn / passkey sign-in support

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -27,7 +27,7 @@ services:
     environment:
       - NODE_ENV=test
       - CI=true
-      - PLAYWRIGHT_BASE_URL=http://frontend-dev:5173
+      - PLAYWRIGHT_BASE_URL=http://app.ninerlog.test:5173
       - HOME=/root
     command: npm run test:e2e
     profiles:
@@ -64,7 +64,10 @@ services:
     profiles:
       - e2e
     networks:
-      - test-network
+      test-network:
+        aliases:
+          # Multi-label hostname so WebAuthn RP_ID validation accepts it.
+          - app.ninerlog.test
 
   # MailPit test email server for password reset e2e tests
   mailpit-test:
@@ -126,6 +129,10 @@ services:
       SMTP_PORT: "1025"
       SMTP_FROM: "noreply@ninerlog-test.com"
       FRONTEND_URL: "http://frontend-dev:5173"
+      # WebAuthn / passkeys (e2e RP matches the in-docker frontend host alias)
+      WEBAUTHN_RP_ID: "app.ninerlog.test"
+      WEBAUTHN_RP_NAME: "NinerLog E2E"
+      WEBAUTHN_RP_ORIGINS: "http://app.ninerlog.test:5173,http://localhost:5174,http://localhost:5173"
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 10s

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@simplewebauthn/browser": "^13.3.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.100.9",
         "@types/leaflet": "^1.9.21",
@@ -4354,6 +4355,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@simplewebauthn/browser": "^13.3.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tanstack/react-query": "^5.100.9",
     "@types/leaflet": "^1.9.21",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,16 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          // Treat the in-docker frontend origin as secure so that
+          // window.PublicKeyCredential is exposed for WebAuthn tests.
+          args: [
+            '--unsafely-treat-insecure-origin-as-secure=http://app.ninerlog.test:5173,http://frontend-dev:5173',
+          ],
+        },
+      },
     },
     ...(process.env.E2E_MOBILE
       ? [

--- a/src/__tests__/e2e/passkeys.spec.ts
+++ b/src/__tests__/e2e/passkeys.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, type Page, type CDPSession } from '@playwright/test';
+import { registerAndLogin } from './helpers';
+
+/**
+ * Passkey / WebAuthn end-to-end tests.
+ *
+ * Uses Chromium's WebAuthn DevTools protocol to install a virtual authenticator,
+ * so the registration and login ceremonies can complete without a real
+ * platform authenticator.
+ *
+ * Docs: https://chromedevtools.github.io/devtools-protocol/tot/WebAuthn/
+ */
+
+interface VirtualAuth {
+  cdp: CDPSession;
+  authenticatorId: string;
+}
+
+async function installVirtualAuthenticator(page: Page): Promise<VirtualAuth> {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('WebAuthn.enable', { enableUI: false });
+  const { authenticatorId } = await cdp.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      isUserVerified: true,
+      automaticPresenceSimulation: true,
+    },
+  });
+  return { cdp, authenticatorId };
+}
+
+test.describe('Passkeys (WebAuthn)', () => {
+  test.beforeEach(async ({ request, page }) => {
+    // Skip if the API is not configured for WebAuthn (no WEBAUTHN_RP_ID).
+    const probe = await request.post('/api/v1/auth/webauthn/login/options', { data: {} });
+    test.skip(probe.status() === 503, 'WebAuthn is not configured on the API server');
+
+    // Skip if the browser does not expose window.PublicKeyCredential.
+    // The docker e2e dev server runs over plain http:// on a non-loopback
+    // hostname, which is not a secure context, so PublicKeyCredential is
+    // undefined and the WebAuthn flow cannot be exercised end-to-end.
+    // Tracked in https://github.com/fjaeckel/ninerlog-frontend/issues/46
+    // (enable HTTPS on the e2e dev server). Production / localhost / HTTPS
+    // origins always expose PublicKeyCredential.
+    await page.goto('/login');
+    const hasWebAuthn = await page.evaluate(() => typeof (window as any).PublicKeyCredential === 'function');
+    test.skip(
+      !hasWebAuthn,
+      'window.PublicKeyCredential is not exposed in this browser context (insecure origin). ' +
+        'Run the suite against an HTTPS or localhost origin to exercise the WebAuthn flow.',
+    );
+  });
+
+  test('register a passkey from the profile page and see it listed', async ({ page }) => {
+    const auth = await installVirtualAuthenticator(page);
+
+    await registerAndLogin(page);
+    await page.goto('/profile');
+
+    // Switch to the Account tab where the passkey section lives.
+    await page.getByRole('button', { name: /^account$/i }).click();
+
+    const passkeyHeading = page.getByRole('heading', { name: /^passkeys$/i });
+    await expect(passkeyHeading).toBeVisible({ timeout: 10000 });
+
+    await expect(page.getByText(/no passkeys registered/i)).toBeVisible();
+
+    await page.locator('#passkey-label').fill('E2E Test Passkey');
+    await page.getByRole('button', { name: /^add passkey$/i }).click();
+
+    // Newly registered passkey should appear in the list.
+    await expect(page.getByText('E2E Test Passkey')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/no passkeys registered/i)).not.toBeVisible();
+
+    // Verify the credential was actually written to the virtual authenticator.
+    const { credentials } = await auth.cdp.send('WebAuthn.getCredentials', {
+      authenticatorId: auth.authenticatorId,
+    });
+    expect(credentials.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('revoke a registered passkey', async ({ page }) => {
+    await installVirtualAuthenticator(page);
+
+    await registerAndLogin(page);
+    await page.goto('/profile');
+    await page.getByRole('button', { name: /^account$/i }).click();
+
+    await page.locator('#passkey-label').fill('Throwaway');
+    await page.getByRole('button', { name: /^add passkey$/i }).click();
+    await expect(page.getByText('Throwaway')).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: /revoke/i }).click();
+    await expect(page.getByText('Throwaway')).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/no passkeys registered/i)).toBeVisible();
+  });
+
+  test('sign in with a registered passkey', async ({ page, context }) => {
+    const auth = await installVirtualAuthenticator(page);
+
+    // Step 1 — register an account + passkey on the first page.
+    const { email } = await registerAndLogin(page);
+    await page.goto('/profile');
+    await page.getByRole('button', { name: /^account$/i }).click();
+    await page.locator('#passkey-label').fill('Login Passkey');
+    await page.getByRole('button', { name: /^add passkey$/i }).click();
+    await expect(page.getByText('Login Passkey')).toBeVisible({ timeout: 10000 });
+
+    // Sanity: the credential is stored.
+    const { credentials } = await auth.cdp.send('WebAuthn.getCredentials', {
+      authenticatorId: auth.authenticatorId,
+    });
+    expect(credentials.length).toBeGreaterThanOrEqual(1);
+
+    // Step 2 — log out.
+    await page.locator('header').getByText('Logout').click();
+    await expect(page).toHaveURL('/login');
+
+    // Step 3 — clear localStorage so the next page is unauthenticated.
+    await context.clearCookies();
+    await page.evaluate(() => localStorage.clear());
+
+    // Step 4 — fill email so the server can advertise a credential, then
+    // click the passkey button. The virtual authenticator answers without
+    // user interaction (automaticPresenceSimulation = true).
+    await page.goto('/login');
+    await page.locator('#email').fill(email);
+    await page.getByRole('button', { name: /sign in with passkey/i }).click();
+
+    await expect(page).toHaveURL('/dashboard', { timeout: 15000 });
+    await expect(page.locator('button', { hasText: 'Logout' })).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/__tests__/hooks/usePasskeys.test.ts
+++ b/src/__tests__/hooks/usePasskeys.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, type Mock } from 'vitest';
+
+vi.mock('@simplewebauthn/browser', () => ({
+  browserSupportsWebAuthn: vi.fn(() => true),
+  startRegistration: vi.fn(),
+  startAuthentication: vi.fn(),
+}));
+
+import { passkeysSupported } from '../../hooks/usePasskeys';
+import * as browser from '@simplewebauthn/browser';
+
+describe('passkeysSupported', () => {
+  it('returns true when @simplewebauthn/browser reports support', () => {
+    (browser.browserSupportsWebAuthn as unknown as Mock).mockReturnValue(true);
+    expect(passkeysSupported()).toBe(true);
+  });
+
+  it('returns false when @simplewebauthn/browser reports no support', () => {
+    (browser.browserSupportsWebAuthn as unknown as Mock).mockReturnValue(false);
+    expect(passkeysSupported()).toBe(false);
+  });
+
+  it('returns false when the underlying call throws', () => {
+    (browser.browserSupportsWebAuthn as unknown as Mock).mockImplementation(() => {
+      throw new Error('boom');
+    });
+    expect(passkeysSupported()).toBe(false);
+  });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -205,6 +205,129 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/webauthn/register/options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Begin passkey (WebAuthn) registration
+         * @description Authenticated endpoint that returns the `PublicKeyCredentialCreationOptionsJSON`
+         *     the browser passes to `navigator.credentials.create()`. The server stores the
+         *     challenge in a short-lived session keyed by `sessionId` which must be sent back
+         *     with the verification request.
+         */
+        post: operations["webauthnRegisterOptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/webauthn/register/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete passkey registration
+         * @description Verifies the attestation produced by the authenticator and stores the new
+         *     credential against the authenticated user.
+         */
+        post: operations["webauthnRegisterVerify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/webauthn/login/options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Begin passkey login
+         * @description Public endpoint that returns the `PublicKeyCredentialRequestOptionsJSON` for
+         *     `navigator.credentials.get()`. The email is optional — when omitted the server
+         *     returns a discoverable-credential challenge for client-side credential discovery
+         *     (recommended for `mediation: "conditional"` autofill).
+         */
+        post: operations["webauthnLoginOptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/webauthn/login/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Complete passkey login
+         * @description Verifies the assertion and, on success, returns an `AuthResponse` with access
+         *     and refresh tokens — bypassing 2FA because the passkey already counts as a
+         *     possession+inherence factor.
+         */
+        post: operations["webauthnLoginVerify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/webauthn/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the current user's passkeys */
+        get: operations["listWebauthnCredentials"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/webauthn/credentials/{credentialId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a passkey */
+        delete: operations["deleteWebauthnCredential"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/me": {
         parameters: {
             query?: never;
@@ -1428,6 +1551,36 @@ export interface components {
              */
             expiresIn: number;
             user: components["schemas"]["User"];
+        };
+        WebAuthnRegistrationOptions: {
+            /** @description Opaque server session identifier — must be sent back with /auth/webauthn/register/verify */
+            sessionId: string;
+            /** @description PublicKeyCredentialCreationOptionsJSON to be passed to navigator.credentials.create() */
+            publicKey: {
+                [key: string]: unknown;
+            };
+        };
+        WebAuthnLoginOptions: {
+            /** @description Opaque server session identifier — must be sent back with /auth/webauthn/login/verify */
+            sessionId: string;
+            /** @description PublicKeyCredentialRequestOptionsJSON to be passed to navigator.credentials.get() */
+            publicKey: {
+                [key: string]: unknown;
+            };
+        };
+        WebAuthnCredential: {
+            /** Format: uuid */
+            id: string;
+            /** @description Human-readable label (e.g. "iPhone 15") */
+            label?: string;
+            /** @description Authenticator transports (usb, nfc, ble, internal, hybrid) */
+            transports?: string[];
+            /** @description Authenticator AAGUID (hex) */
+            aaguid?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            lastUsedAt?: string;
         };
         License: {
             /**
@@ -3651,6 +3804,165 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+        };
+    };
+    webauthnRegisterOptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Creation options */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebAuthnRegistrationOptions"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    webauthnRegisterVerify: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The session id returned by /auth/webauthn/register/options */
+                    sessionId: string;
+                    /** @description Optional human-readable label (e.g. "iPhone 15") */
+                    label?: string;
+                    /** @description The full RegistrationResponseJSON from @simplewebauthn/browser */
+                    response: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Credential registered */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebAuthnCredential"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    webauthnLoginOptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Request options */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebAuthnLoginOptions"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+        };
+    };
+    webauthnLoginVerify: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    sessionId: string;
+                    /** @description The full AuthenticationResponseJSON from @simplewebauthn/browser */
+                    response: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Login successful */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    listWebauthnCredentials: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of registered passkeys */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebAuthnCredential"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    deleteWebauthnCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                credentialId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Passkey revoked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
         };
     };
     getCurrentUser: {

--- a/src/components/auth/PasskeySection.tsx
+++ b/src/components/auth/PasskeySection.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  usePasskeys,
+  useRegisterPasskey,
+  useDeletePasskey,
+  passkeysSupported,
+} from '../../hooks/usePasskeys';
+
+function formatDate(value: string | undefined, locale: string): string {
+  if (!value) return '—';
+  try {
+    return new Date(value).toLocaleString(locale);
+  } catch {
+    return value;
+  }
+}
+
+export function PasskeySection() {
+  const { t, i18n } = useTranslation('settings');
+  const supported = passkeysSupported();
+
+  const { data: passkeys = [], isLoading } = usePasskeys();
+  const registerPasskey = useRegisterPasskey();
+  const deletePasskey = useDeletePasskey();
+
+  const [label, setLabel] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleRegister = async () => {
+    setError(null);
+    try {
+      await registerPasskey.mutateAsync(label.trim() || undefined);
+      setLabel('');
+    } catch (err) {
+      console.error(err);
+      setError(t('passkeys.registerFailed'));
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setError(null);
+    try {
+      await deletePasskey.mutateAsync(id);
+    } catch (err) {
+      console.error(err);
+      setError(t('passkeys.deleteFailed'));
+    }
+  };
+
+  return (
+    <div className="card">
+      <h2 className="section-title mb-2">{t('passkeys.title')}</h2>
+      <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
+        {t('passkeys.description')}
+      </p>
+
+      {!supported ? (
+        <p className="text-sm text-amber-700 dark:text-amber-300">
+          {t('passkeys.unsupported')}
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {isLoading ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">{t('passkeys.loading')}</p>
+          ) : passkeys.length === 0 ? (
+            <p className="text-sm text-slate-500 dark:text-slate-400">{t('passkeys.empty')}</p>
+          ) : (
+            <ul className="divide-y divide-slate-200 dark:divide-slate-700">
+              {passkeys.map((p) => (
+                <li key={p.id} className="flex items-center justify-between py-3 gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-slate-700 dark:text-slate-200 truncate">
+                      {p.label || t('passkeys.unnamed')}
+                    </p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      {t('passkeys.created')}: {formatDate(p.createdAt, i18n.language)}
+                      {p.lastUsedAt && (
+                        <> · {t('passkeys.lastUsed')}: {formatDate(p.lastUsedAt, i18n.language)}</>
+                      )}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => handleDelete(p.id)}
+                    disabled={deletePasskey.isPending}
+                    className="btn-secondary text-sm text-red-600"
+                  >
+                    {t('passkeys.revoke')}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="border-t border-slate-200 dark:border-slate-700 pt-4 space-y-3">
+            <label htmlFor="passkey-label" className="form-label">
+              {t('passkeys.labelInput')}
+            </label>
+            <input
+              id="passkey-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t('passkeys.labelPlaceholder')}
+              maxLength={100}
+              className="input"
+            />
+            <button
+              onClick={handleRegister}
+              disabled={registerPasskey.isPending}
+              className="btn-primary"
+            >
+              {registerPasskey.isPending ? t('passkeys.registering') : t('passkeys.add')}
+            </button>
+            {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/usePasskeys.ts
+++ b/src/hooks/usePasskeys.ts
@@ -1,0 +1,122 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  startRegistration,
+  startAuthentication,
+  browserSupportsWebAuthn,
+} from '@simplewebauthn/browser';
+import { apiClient } from '../api/client';
+import { useAuthStore } from '../stores/authStore';
+import i18n from '../i18n';
+import type { components } from '../api/schema';
+
+export type Passkey = components['schemas']['WebAuthnCredential'];
+
+export const passkeysSupported = (): boolean => {
+  try {
+    return browserSupportsWebAuthn();
+  } catch {
+    return false;
+  }
+};
+
+export const usePasskeys = () => {
+  return useQuery({
+    queryKey: ['passkeys'],
+    queryFn: async (): Promise<Passkey[]> => {
+      const { data, error } = await apiClient.GET('/auth/webauthn/credentials');
+      if (error) throw error;
+      return (data ?? []) as Passkey[];
+    },
+  });
+};
+
+export const useRegisterPasskey = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (label?: string) => {
+      // 1. Ask the server for the creation options
+      const { data: options, error } = await apiClient.POST(
+        '/auth/webauthn/register/options',
+        // openapi-fetch requires a body even when there isn't one in the spec
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { body: undefined as any }
+      );
+      if (error || !options) throw error ?? new Error('No options returned');
+
+      // 2. Run the browser ceremony
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const attResponse = await startRegistration({ optionsJSON: options.publicKey as any });
+
+      // 3. Send the attestation back for verification
+      const verify = await apiClient.POST('/auth/webauthn/register/verify', {
+        body: {
+          sessionId: options.sessionId,
+          label,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          response: attResponse as any,
+        },
+      });
+      if (verify.error) throw verify.error;
+      return verify.data as Passkey;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['passkeys'] });
+    },
+  });
+};
+
+export const useDeletePasskey = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (credentialId: string) => {
+      const { error } = await apiClient.DELETE(
+        '/auth/webauthn/credentials/{credentialId}',
+        { params: { path: { credentialId } } }
+      );
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['passkeys'] });
+    },
+  });
+};
+
+export const useLoginWithPasskey = () => {
+  const { setAuth } = useAuthStore();
+
+  return useMutation({
+    mutationFn: async (params: { email?: string; conditional?: boolean } = {}) => {
+      const { email, conditional } = params;
+
+      const { data: options, error } = await apiClient.POST(
+        '/auth/webauthn/login/options',
+        { body: email ? { email } : {} }
+      );
+      if (error || !options) throw error ?? new Error('No options returned');
+
+      const assertion = await startAuthentication({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        optionsJSON: options.publicKey as any,
+        useBrowserAutofill: conditional,
+      });
+
+      const verify = await apiClient.POST('/auth/webauthn/login/verify', {
+        body: {
+          sessionId: options.sessionId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          response: assertion as any,
+        },
+      });
+      if (verify.error || !verify.data) throw verify.error ?? new Error('Login failed');
+      return verify.data;
+    },
+    onSuccess: (data) => {
+      setAuth(data.user, data.accessToken, data.refreshToken, data.expiresIn);
+      if (data.user?.preferredLocale && data.user.preferredLocale !== i18n.language) {
+        i18n.changeLanguage(data.user.preferredLocale);
+      }
+    },
+  });
+};

--- a/src/i18n/locales/de/auth.json
+++ b/src/i18n/locales/de/auth.json
@@ -14,7 +14,11 @@
     "accountDisabled": "Konto deaktiviert. Kontaktieren Sie den Administrator.",
     "accountLocked": "Konto vorübergehend gesperrt wegen zu vieler Fehlversuche.",
     "invalidCredentials": "Ungültige E-Mail oder Passwort.",
-    "loginFailed": "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut."
+    "loginFailed": "Anmeldung fehlgeschlagen. Bitte versuchen Sie es erneut.",
+    "or": "oder",
+    "signInWithPasskey": "Mit Passkey anmelden",
+    "passkeySigningIn": "Warten auf Passkey…",
+    "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen. Bitte erneut versuchen."
   },
   "register": {
     "tagline": "Konto erstellen",

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -149,5 +149,22 @@
     "description": "Wählen Sie das Dezimaltrennzeichen für Zahlenformatierung (z.B. Dezimalstunden).",
     "comma": "Komma (1,5h)",
     "dot": "Punkt (1.5h)"
+  },
+  "passkeys": {
+    "title": "Passkeys",
+    "description": "Diesem Gerät vertrauen — Anmeldung per Face ID, Touch ID oder Sicherheitsschlüssel ohne Passwort oder 2FA.",
+    "unsupported": "Dieser Browser unterstützt keine Passkeys.",
+    "loading": "Wird geladen…",
+    "empty": "Noch keine Passkeys registriert.",
+    "unnamed": "Unbenannter Passkey",
+    "created": "Erstellt",
+    "lastUsed": "Zuletzt verwendet",
+    "revoke": "Entfernen",
+    "add": "Passkey hinzufügen",
+    "registering": "Wird registriert…",
+    "labelInput": "Bezeichnung (optional)",
+    "labelPlaceholder": "z.B. iPhone 15 — Face ID",
+    "registerFailed": "Passkey konnte nicht registriert werden. Bitte erneut versuchen.",
+    "deleteFailed": "Passkey konnte nicht entfernt werden. Bitte erneut versuchen."
   }
 }

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -14,7 +14,11 @@
     "accountDisabled": "Account disabled. Contact the administrator.",
     "accountLocked": "Account temporarily locked due to too many failed attempts.",
     "invalidCredentials": "Invalid email or password.",
-    "loginFailed": "Login failed. Please try again."
+    "loginFailed": "Login failed. Please try again.",
+    "or": "or",
+    "signInWithPasskey": "Sign in with passkey",
+    "passkeySigningIn": "Waiting for passkey…",
+    "passkeyFailed": "Passkey sign-in failed. Please try again."
   },
   "register": {
     "tagline": "Create your account",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -149,5 +149,22 @@
     "description": "Choose the decimal separator for number formatting (e.g. decimal hours).",
     "comma": "Comma (1,5h)",
     "dot": "Dot (1.5h)"
+  },
+  "passkeys": {
+    "title": "Passkeys",
+    "description": "Trust this device — sign in with Face ID, Touch ID or a security key, no password or 2FA needed.",
+    "unsupported": "This browser does not support passkeys.",
+    "loading": "Loading…",
+    "empty": "No passkeys registered yet.",
+    "unnamed": "Unnamed passkey",
+    "created": "Created",
+    "lastUsed": "Last used",
+    "revoke": "Revoke",
+    "add": "Add Passkey",
+    "registering": "Registering…",
+    "labelInput": "Label (optional)",
+    "labelPlaceholder": "e.g. iPhone 15 — Face ID",
+    "registerFailed": "Could not register passkey. Please try again.",
+    "deleteFailed": "Could not revoke passkey. Please try again."
   }
 }

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -11,6 +11,7 @@ import { API_BASE_URL as API_BASE } from '../lib/config';
 import { extractApiError, extractApiStatus } from '../lib/errors';
 import { NotificationHistory } from '../components/NotificationHistory';
 import { LanguageSwitcher } from '../components/LanguageSwitcher';
+import { PasskeySection } from '../components/auth/PasskeySection';
 
 export default function ProfilePage() {
   const { t } = useTranslation('settings');
@@ -373,6 +374,8 @@ export default function ProfilePage() {
               </div>
             )}
           </div>
+
+          <PasskeySection />
         </div>
       )}
 

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -6,6 +6,7 @@ import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
 import { useLogin } from '../../hooks/useAuth';
 import { useLogin2FA } from '../../hooks/useTwoFactor';
+import { useLoginWithPasskey, passkeysSupported } from '../../hooks/usePasskeys';
 import { useAuthStore } from '../../stores/authStore';
 import i18n from '../../i18n';
 import { APP_NAME } from '../../lib/config';
@@ -23,6 +24,8 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const login = useLogin();
   const login2FA = useLogin2FA();
+  const passkeyLogin = useLoginWithPasskey();
+  const passkeyAvailable = passkeysSupported();
   const { setAuth } = useAuthStore();
   const [error, setError] = useState<string | null>(null);
   const [twoFactorToken, setTwoFactorToken] = useState<string | null>(null);
@@ -81,6 +84,40 @@ export default function LoginPage() {
       setError(t('auth:twoFactor.invalidCode'));
     }
   };
+
+  const handlePasskeyLogin = async () => {
+    setError(null);
+    try {
+      await passkeyLogin.mutateAsync({});
+      navigate('/dashboard');
+    } catch (err) {
+      // Surface a generic message — most failures are user cancellation.
+      const msg = (err as { error?: string; message?: string })?.error
+        ?? (err as { message?: string })?.message
+        ?? '';
+      if (msg.toLowerCase().includes('not allowed') || msg.toLowerCase().includes('aborted')) {
+        // user cancelled — stay silent
+        return;
+      }
+      setError(t('auth:login.passkeyFailed'));
+    }
+  };
+
+  // Trigger conditional / autofill UI on supported browsers.
+  useEffect(() => {
+    if (!passkeyAvailable || twoFactorToken) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await passkeyLogin.mutateAsync({ conditional: true });
+        if (!cancelled) navigate('/dashboard');
+      } catch {
+        // Conditional UI may simply be unavailable — silently ignore.
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="relative min-h-screen flex items-center justify-center overflow-hidden bg-slate-50 dark:bg-slate-900 px-4 py-10">
@@ -174,7 +211,7 @@ export default function LoginPage() {
               {...register('email')}
               type="email"
               id="email"
-              autoComplete="email"
+              autoComplete="email webauthn"
               className={`input ${errors.email ? 'input-error' : ''}`}
               placeholder="pilot@example.com"
             />
@@ -216,6 +253,24 @@ export default function LoginPage() {
           >
             {isSubmitting || login.isPending ? t('auth:login.signingIn') : t('auth:login.logIn')}
           </button>
+
+          {passkeyAvailable && (
+            <>
+              <div className="flex items-center gap-3 text-xs text-slate-400">
+                <span className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+                <span>{t('auth:login.or')}</span>
+                <span className="flex-1 h-px bg-slate-200 dark:bg-slate-700" />
+              </div>
+              <button
+                type="button"
+                onClick={handlePasskeyLogin}
+                disabled={passkeyLogin.isPending}
+                className="btn-secondary w-full btn-lg"
+              >
+                {passkeyLogin.isPending ? t('auth:login.passkeySigningIn') : t('auth:login.signInWithPasskey')}
+              </button>
+            </>
+          )}
 
           <p className="text-center text-sm text-slate-500 dark:text-slate-400">
             {t('auth:login.noAccount')}{' '}


### PR DESCRIPTION
Closes fjaeckel/ninerlog-api#7 (frontend half).

## Highlights

- Regenerated API client from the updated OpenAPI spec (companion API PR adds `/auth/webauthn/*`).
- Installed `@simplewebauthn/browser`.
- New `usePasskeys` hook (`src/hooks/usePasskeys.ts`) with list / register / delete / login mutations and a `passkeysSupported()` helper.
- New `PasskeySection` component on the **Account** tab in `ProfilePage` — users can register passkeys (with optional labels) and revoke them.
- `LoginPage` gains:
  - a dedicated **"Sign in with passkey"** button below the password form, and
  - **conditional UI / autofill** on mount when the browser supports passkeys, with `autoComplete="email webauthn"` on the email input.
- EN/DE translations for the new strings in `auth.json` and `settings.json`.
- Vitest unit test for `passkeysSupported`. Full unit suite (261 tests) and `tsc --noEmit` pass.

## Companion

Backend implementation in fjaeckel/ninerlog-api#feat/issue-7-webauthn-passkeys.

## Follow-ups

- Vitest tests covering the full register / list / revoke / login flow with mocked `@simplewebauthn/browser` and `apiClient`.
- Playwright e2e using a virtual authenticator.