### PR TITLE
feat(auth): WebAuthn / passkey sign-in (closes #7)

### DIFF
--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -25,6 +25,9 @@ export default function LoginPage() {
   const login = useLogin();
   const login2FA = useLogin2FA();
   const passkeyLogin = useLoginWithPasskey();
+  // Separate mutation instance so the conditional/autofill ceremony's pending
+  // state never drives the explicit "Sign in with passkey" button.
+  const passkeyConditional = useLoginWithPasskey();
   const passkeyAvailable = passkeysSupported();
   const { setAuth } = useAuthStore();
   const [error, setError] = useState<string | null>(null);
@@ -109,7 +112,15 @@ export default function LoginPage() {
     let cancelled = false;
     (async () => {
       try {
-        await passkeyLogin.mutateAsync({ conditional: true });
+        // Only attempt conditional mediation if the browser actually supports
+        // it. Otherwise startAuthentication() will hang indefinitely waiting
+        // for an autofill suggestion that can never be produced, leaving the
+        // mutation in a permanent "pending" state.
+        const PKC = (window as unknown as { PublicKeyCredential?: { isConditionalMediationAvailable?: () => Promise<boolean> } }).PublicKeyCredential;
+        if (!PKC?.isConditionalMediationAvailable) return;
+        const supported = await PKC.isConditionalMediationAvailable();
+        if (!supported || cancelled) return;
+        await passkeyConditional.mutateAsync({ conditional: true });
         if (!cancelled) navigate('/dashboard');
       } catch {
         // Conditional UI may simply be unavailable — silently ignore.


### PR DESCRIPTION
Adds WebAuthn / passkey sign-in to the frontend, paired with the matching API change in fjaeckel/ninerlog-api#<see branch feat/issue-7-webauthn-passkeys>.

## What

- New \`usePasskeys\` hooks (\`useRegisterPasskey\`, \`useDeletePasskey\`, \`useLoginWithPasskey\`, \`usePasskeys\`) wrapping \`@simplewebauthn/browser\` and the generated OpenAPI client.
- Login page integration:
  - \"Sign in with passkey\" button (only when \`browserSupportsWebAuthn()\`).
  - Conditional / autofill ceremony triggered on mount when supported, so saved passkeys appear in the browser's username autofill UI.
- Profile page passkey management (list / register / revoke).
- Playwright e2e flow using a virtual authenticator covering register, list, revoke, and sign-in.

## Fix included in this PR (last commit)

The previous revision had a UX bug: the conditional/autofill ceremony shared its mutation instance with the explicit \"Sign in with passkey\" button. On browsers that can't satisfy conditional mediation (or where no synced credential exists for this RP), \`startAuthentication\` hangs indefinitely, leaving the mutation in a permanent \`isPending\` state. That disabled the button and pinned its label to \"Waiting for passkey…\" with no way to actually invoke the modal flow.

Fix:
- Use a **separate** \`useLoginWithPasskey()\` mutation instance for the conditional ceremony.
- Gate the conditional ceremony on \`PublicKeyCredential.isConditionalMediationAvailable()\` and skip it when unsupported.

## Tests

- Unit (vitest): 261 passing.
- E2E (Playwright, Docker, against real API): 79 passing; 3 passkey specs skipped in this environment (require virtual authenticator support not enabled in the Docker chromium image).

Closes #7