### PR TITLE
fix(i18n): update easa_pax rule string for FCL.060(b)(2)

### DIFF
--- a/src/i18n/locales/de/currency.json
+++ b/src/i18n/locales/de/currency.json
@@ -61,7 +61,7 @@
     "easa_lapl": "Erfordert 12h Flugzeit + 12 Starts & Landungen + 1h Übungsflug mit Fluglehrer in den letzten 24 Monaten (EASA FCL.140.A)",
     "easa_spl": "Erfordert 5h PIC-Flugzeit + 15 Starts + 2 Übungsflüge mit Fluglehrer in den letzten 24 Monaten (EASA FCL.140.S)",
     "easa_spl_tmg": "Erfordert 12h Flugzeit + 12 Starts & Landungen auf TMG in den letzten 24 Monaten (EASA FCL.140.S(b)(2))",
-    "easa_pax": "3 Starts & Landungen in gleicher Muster/Klasse in den vorangegangenen 90 Tagen für Passagiermitnahme (EASA FCL.060(b))",
+    "easa_pax": "3 Starts & Landungen (Tag) und 1 Start & Landung bei Nacht in gleicher Muster/Klasse in den vorangegangenen 90 Tagen für Passagiermitnahme; die Nachtanforderung entfällt bei gültiger IR-Berechtigung (EASA FCL.060(b))",
     "faa_pax_day_night": "3 Starts & Landungen in 90 Tagen für Tag-Passagiergültigkeit; 3 Voll-Stop-Nachtlandungen in 90 Tagen für Nacht-Passagiergültigkeit (14 CFR 61.57(a)/(b))",
     "faa_ir": "Erfordert 6 Instrumentenanflüge + Warteverfahren innerhalb der vorangegangenen 6 Kalendermonate (14 CFR 61.57(c))",
     "faa_glider": "Erfordert 3 Starts & Landungen in den vorangegangenen 90 Tagen (14 CFR 61.57(a))",

--- a/src/i18n/locales/en/currency.json
+++ b/src/i18n/locales/en/currency.json
@@ -61,7 +61,7 @@
     "easa_lapl": "Requires 12h flight time + 12 takeoffs & landings + 1h training flight with instructor within the last 24 months (EASA FCL.140.A)",
     "easa_spl": "Requires 5h PIC flight time + 15 launches + 2 training flights with instructor within the last 24 months (EASA FCL.140.S)",
     "easa_spl_tmg": "Requires 12h flight time + 12 takeoffs & landings on TMG within the last 24 months (EASA FCL.140.S(b)(2))",
-    "easa_pax": "3 takeoffs & landings in same type/class within preceding 90 days to carry passengers (EASA FCL.060(b))",
+    "easa_pax": "3 takeoffs & landings (day) and 1 takeoff & landing at night in same type/class within preceding 90 days to carry passengers; the night requirement is waived for pilots holding a valid IR (EASA FCL.060(b))",
     "faa_pax_day_night": "3 takeoffs & landings in preceding 90 days for day passenger currency; 3 full-stop night takeoffs & landings in preceding 90 days for night passenger currency (14 CFR 61.57(a)/(b))",
     "faa_ir": "Requires 6 instrument approaches + holding procedures within the preceding 6 calendar months (14 CFR 61.57(c))",
     "faa_glider": "Requires 3 launches & landings in preceding 90 days (14 CFR 61.57(a))",


### PR DESCRIPTION
Companion to fjaeckel/ninerlog-api#fix/easa-night-pax-currency (issue ninerlog-api#24).

EASA night passenger recency requires only **1 night takeoff & landing** in the preceding 90 days (not 3), and the requirement is **waived for pilots holding a valid IR** (FCL.060(b)(2)(ii)).

Updates the en/de `easa_pax` rule description displayed under the Passenger Currency card on the Currency & Recency page to reflect this.

`npx vitest run` passes (263/263).