### PR TITLE
fix(currency): correct EASA Class 1 medical validity description

### DIFF
--- a/src/pages/currency/CurrencyPage.tsx
+++ b/src/pages/currency/CurrencyPage.tsx
@@ -18,7 +18,7 @@ const CLASS_TYPE_LABELS: Record<string, string> = {
 };
 
 const CREDENTIAL_DESCRIPTIONS: Record<string, string> = {
-  EASA_CLASS1_MEDICAL: 'EASA Class 1 Medical — valid for 12 months (6 months after age 40 for ATPL holders)',
+  EASA_CLASS1_MEDICAL: 'EASA Class 1 Medical — valid for 12 months (6 months for single-pilot CAT passenger operations after age 40, and for all holders after age 60)',
   EASA_CLASS2_MEDICAL: 'EASA Class 2 Medical — valid for 60 months if issued before age 40, 24 months after age 40',
   EASA_LAPL_MEDICAL: 'EASA LAPL Medical — valid for 60 months if issued before age 40, 24 months after age 40',
   FAA_CLASS1_MEDICAL: 'FAA Class 1 Medical — valid for 12 months (6 months after age 40)',


### PR DESCRIPTION
Resolves fjaeckel/ninerlog-api#23.

The Currency & Recency page incorrectly described the EASA Class 1 medical validity rule. The previous text said:

> EASA Class 1 Medical — valid for 12 months (6 months after age 40 for ATPL holders)

Per **EASA MED.A.045(a)** the 6‑month period only applies to licence holders who:

1. are engaged in **single‑pilot commercial air transport operations carrying passengers** and have reached age 40, **or**
2. have reached age 60.

It also applies to all Class 1 holders (CPL **and** ATPL), not just ATPL. In a multi‑crew cockpit the validity remains 12 months even after age 40.

### Change
Updated the description string in [src/pages/currency/CurrencyPage.tsx](src/pages/currency/CurrencyPage.tsx#L21) to:

> EASA Class 1 Medical — valid for 12 months (6 months for single-pilot CAT passenger operations after age 40, and for all holders after age 60)

### Tests
- `npx vitest run` → 263/263 passing.
