### PR TITLE
feat(layout): add 'Report a Bug' quick link and Help page CTA

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Outlet, Link, NavLink, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard, Plane, FileText, PlaneTakeoff, BarChart3, Map,
-  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle
+  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle, Bug, ExternalLink
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useLogout } from '../../hooks/useAuth';
@@ -107,6 +107,12 @@ export default function Layout() {
             <SidebarItem to="/admin" label={t('nav:admin')} icon={<ShieldCheck className="w-5 h-5" />} />
           )}
           <SidebarItem to="/help" label={t('nav:help')} icon={<HelpCircle className="w-5 h-5" />} />
+          <SidebarExternalItem
+            href="https://ninerlog.com/report-a-bug"
+            label={t('nav:reportBug')}
+            title={t('nav:reportBugTooltip')}
+            icon={<Bug className="w-5 h-5" />}
+          />
           <SidebarItem to="/profile" label={t('nav:profileSettings')} icon={<User className="w-5 h-5" />} />
         </div>
       </aside>
@@ -170,6 +176,13 @@ export default function Layout() {
               <MoreMenuItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/profile" label={t('nav:profileSettings')} icon={<User className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/help" label={t('nav:help')} icon={<HelpCircle className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
+              <MoreMenuExternalItem
+                href="https://ninerlog.com/report-a-bug"
+                label={t('nav:reportBug')}
+                title={t('nav:reportBugTooltip')}
+                icon={<Bug className="w-5 h-5" />}
+                onClick={() => setShowMoreMenu(false)}
+              />
               {user?.isAdmin && (
                 <MoreMenuItem to="/admin" label={t('nav:admin')} icon={<ShieldCheck className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               )}
@@ -259,5 +272,38 @@ function MoreMenuItem({ to, label, icon, onClick }: { to: string; label: string;
       <span className="shrink-0" aria-hidden="true">{icon}</span>
       {label}
     </NavLink>
+  );
+}
+
+function SidebarExternalItem({ href, label, title, icon }: { href: string; label: string; title?: string; icon: React.ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      className="relative flex items-center gap-3 px-3 py-2 rounded-md text-sm font-medium transition-colors tap-none text-slate-600 dark:text-slate-400 hover:bg-slate-50 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-slate-200"
+    >
+      <span className="shrink-0" aria-hidden="true">{icon}</span>
+      <span className="flex-1">{label}</span>
+      <ExternalLink className="w-3.5 h-3.5 text-slate-400" aria-hidden="true" />
+    </a>
+  );
+}
+
+function MoreMenuExternalItem({ href, label, title, icon, onClick }: { href: string; label: string; title?: string; icon: React.ReactNode; onClick: () => void }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={title}
+      onClick={onClick}
+      className="flex items-center gap-3 px-3 py-3 rounded-lg text-sm font-medium transition-colors text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700"
+    >
+      <span className="shrink-0" aria-hidden="true">{icon}</span>
+      <span className="flex-1">{label}</span>
+      <ExternalLink className="w-3.5 h-3.5 text-slate-400" aria-hidden="true" />
+    </a>
   );
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -87,6 +87,11 @@
       "reports": "Berichte & Karten",
       "profile": "Profil & Einstellungen",
       "admin": "Admin-Konsole"
+    },
+    "reportBug": {
+      "title": "Einen Gremlin im Cockpit entdeckt?",
+      "body": "Squawk it. Jeder gemeldete Fehler hält die ganze Flotte am Laufen — kein PIREP ist zu klein.",
+      "cta": "Fehler melden"
     }
   },
   "admin": {

--- a/src/i18n/locales/de/nav.json
+++ b/src/i18n/locales/de/nav.json
@@ -11,6 +11,8 @@
   "export": "Export",
   "admin": "Admin",
   "help": "Hilfe",
+  "reportBug": "Fehler melden",
+  "reportBugTooltip": "Squawk it — öffnet ninerlog.com",
   "profileSettings": "Profil & Einstellungen",
   "home": "Start",
   "addFlight": "Flug hinzufügen",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -87,6 +87,11 @@
       "reports": "Reports & Maps",
       "profile": "Profile & Settings",
       "admin": "Admin Console"
+    },
+    "reportBug": {
+      "title": "Spotted a gremlin in the cockpit?",
+      "body": "Squawk it. Every bug you report keeps the whole fleet flying smoothly — no PIREP too small.",
+      "cta": "Report a bug"
     }
   },
   "admin": {

--- a/src/i18n/locales/en/nav.json
+++ b/src/i18n/locales/en/nav.json
@@ -11,6 +11,8 @@
   "export": "Export",
   "admin": "Admin",
   "help": "Help",
+  "reportBug": "Report a Bug",
+  "reportBugTooltip": "Squawk it — opens ninerlog.com",
   "profileSettings": "Profile & Settings",
   "home": "Home",
   "addFlight": "Add Flight",

--- a/src/pages/help/HelpPage.tsx
+++ b/src/pages/help/HelpPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { HelpCircle, Plane, Award, FileText, PlaneTakeoff, Upload, Shield, BarChart3, User, ShieldCheck, BookOpen, Search, X } from 'lucide-react';
+import { HelpCircle, Plane, Award, FileText, PlaneTakeoff, Upload, Shield, BarChart3, User, ShieldCheck, BookOpen, Search, X, Bug, ExternalLink } from 'lucide-react';
 import { useHelpContent, helpSectionIds, type HelpSectionId } from './content';
 import { APP_NAME } from '../../lib/config';
 
@@ -172,6 +172,26 @@ export default function HelpPage() {
                 <Markdown remarkPlugins={[remarkGfm]}>{activeSection.content}</Markdown>
               </article>
             </div>
+
+            {/* Report-a-bug call to action — hidden on print */}
+            <a
+              href="https://ninerlog.com/report-a-bug"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 print:hidden flex items-start gap-4 p-4 sm:p-5 rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50/60 dark:bg-amber-900/10 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors group"
+            >
+              <span className="shrink-0 w-10 h-10 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-600 dark:text-amber-400 flex items-center justify-center" aria-hidden="true">
+                <Bug className="w-5 h-5" />
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100">{t('help.reportBug.title')}</h2>
+                  <ExternalLink className="w-3.5 h-3.5 text-slate-400 group-hover:text-amber-600 dark:group-hover:text-amber-400 transition-colors" aria-hidden="true" />
+                </div>
+                <p className="text-sm text-slate-600 dark:text-slate-300 mt-1">{t('help.reportBug.body')}</p>
+                <span className="inline-block mt-2 text-sm font-medium text-amber-700 dark:text-amber-300 group-hover:underline">{t('help.reportBug.cta')} →</span>
+              </div>
+            </a>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Adds a discoverable, in-app path for users to report bugs. Every entry point opens https://ninerlog.com/report-a-bug in a new tab, where users can choose between filing a GitHub issue (preferred) or emailing `hej@ninerlog.com`.

## Why

There was no in-app way to surface where bug reports should go. With the new bug-reporting page on `ninerlog.com` shipped, the app needs visible hooks pointing at it.

## What changed

- **Desktop sidebar** (bottom block, [`src/components/layout/Layout.tsx`](src/components/layout/Layout.tsx)): new external "Report a Bug" item with a `Bug` icon, sitting right next to Help.
- **Mobile More menu**: matching external item with the same icon and label.
- **Help page** ([`src/pages/help/HelpPage.tsx`](src/pages/help/HelpPage.tsx)): amber call-to-action card directly after the article body — _"Spotted a gremlin in the cockpit? Squawk it."_
- **i18n**: added `nav.reportBug` + `nav.reportBugTooltip` and `common.help.reportBug` (title / body / cta) in both `en` and `de` locales.

## Tone

Per request, leaned into a cheeky aviation reference: _squawk it_, _gremlin in the cockpit_, _no PIREP too small_. Kept understated; no emojis.

## Verification

- `npx vitest run` → **263/263 passing**.
- TypeScript: no errors in changed files.
- Note on Playwright: navigation e2e specs failed locally with `ECONNREFUSED` against the API on :3000 (no backend running) — pre-existing infrastructure issue, unrelated to this change. The new entries are external `<a>` links so they don't affect existing route-based selectors.
