### PR TITLE
feat(flights): show IFR / instrument data in flight detail view

### DIFF
--- a/src/i18n/locales/de/flights.json
+++ b/src/i18n/locales/de/flights.json
@@ -149,6 +149,8 @@
     "blockTimes": "Blockzeiten",
     "takeoffsAndLandings": "Starts & Landungen",
     "remarksAndComments": "Bemerkungen & Kommentare",
+    "instrumentAndApproaches": "Instrumentenflug & Anflüge",
+    "yes": "Ja",
     "peopleOnBoard": "Personen an Bord",
     "aircraft": "Luftfahrzeug",
     "departure": "Abflug",

--- a/src/i18n/locales/en/flights.json
+++ b/src/i18n/locales/en/flights.json
@@ -149,6 +149,8 @@
     "blockTimes": "Block Times",
     "takeoffsAndLandings": "Takeoffs & Landings",
     "remarksAndComments": "Remarks & Comments",
+    "instrumentAndApproaches": "Instrument & Approaches",
+    "yes": "Yes",
     "peopleOnBoard": "People on Board",
     "aircraft": "Aircraft",
     "departure": "Departure",

--- a/src/pages/flights/FlightDetailPage.tsx
+++ b/src/pages/flights/FlightDetailPage.tsx
@@ -53,6 +53,15 @@ export default function FlightDetailPage() {
   const totalLandings = flight.allLandings;
   const totalTakeoffs = flight.takeoffsDay + flight.takeoffsNight;
 
+  const hasInstrumentData =
+    (flight.ifrTime ?? 0) > 0 ||
+    (flight.actualInstrumentTime ?? 0) > 0 ||
+    (flight.simulatedInstrumentTime ?? 0) > 0 ||
+    (flight.holds ?? 0) > 0 ||
+    (flight.approachesCount ?? 0) > 0 ||
+    (flight.approaches && flight.approaches.length > 0) ||
+    !!flight.isIpc;
+
   const handleDelete = async () => {
     await deleteFlight.mutateAsync(flight.id);
     navigate('/flights');
@@ -66,7 +75,6 @@ export default function FlightDetailPage() {
     { label: t('fields.soloTime'), value: flight.soloTime },
     { label: t('detail.crossCountry'), value: flight.crossCountryTime },
     { label: t('fields.nightTime'), value: flight.nightTime },
-    { label: t('fields.ifrTime'), value: flight.ifrTime },
     { label: t('detail.sicTime'), value: flight.sicTime || 0 },
     { label: t('detail.dualGiven'), value: flight.dualGivenTime || 0 },
     { label: t('detail.simulatedFlight'), value: flight.simulatedFlightTime || 0 },
@@ -208,6 +216,61 @@ export default function FlightDetailPage() {
             </div>
           </dl>
         </div>
+
+        {/* Instrument & Approaches */}
+        {hasInstrumentData && (
+          <div className="card">
+            <h2 className="section-title mb-4">{t('detail.instrumentAndApproaches')}</h2>
+            <dl className="space-y-3">
+              <div className="flex justify-between">
+                <dt className="text-slate-500 dark:text-slate-400">{t('fields.ifrTime')}</dt>
+                <dd className={`font-medium font-mono tabular-nums ${flight.ifrTime > 0 ? 'text-slate-800 dark:text-slate-100' : 'text-slate-300 dark:text-slate-600'}`}>
+                  {fmtDuration(flight.ifrTime)}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-slate-500 dark:text-slate-400">{t('fields.actualInstrumentTime')}</dt>
+                <dd className={`font-medium font-mono tabular-nums ${(flight.actualInstrumentTime ?? 0) > 0 ? 'text-slate-800 dark:text-slate-100' : 'text-slate-300 dark:text-slate-600'}`}>
+                  {fmtDuration(flight.actualInstrumentTime ?? 0)}
+                </dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-slate-500 dark:text-slate-400">{t('fields.simulatedInstrumentTime')}</dt>
+                <dd className={`font-medium font-mono tabular-nums ${(flight.simulatedInstrumentTime ?? 0) > 0 ? 'text-slate-800 dark:text-slate-100' : 'text-slate-300 dark:text-slate-600'}`}>
+                  {fmtDuration(flight.simulatedInstrumentTime ?? 0)}
+                </dd>
+              </div>
+              <DetailRow label={t('fields.holds')} value={String(flight.holds ?? 0)} mono />
+              <DetailRow label={t('fields.approaches')} value={String(flight.approachesCount ?? 0)} mono />
+              {flight.isIpc && (
+                <div className="flex justify-between">
+                  <dt className="text-slate-500 dark:text-slate-400">{t('fields.isIpc')}</dt>
+                  <dd>
+                    <span className="badge-info text-xs">{t('detail.yes')}</span>
+                  </dd>
+                </div>
+              )}
+              {flight.approaches && flight.approaches.length > 0 && (
+                <div className="border-t border-slate-200 dark:border-slate-700 pt-3">
+                  <dt className="text-slate-500 dark:text-slate-400 text-sm mb-2">{t('fields.approaches')}</dt>
+                  <ul className="space-y-1.5">
+                    {flight.approaches.map((a, idx) => (
+                      <li key={idx} className="flex items-center gap-2 text-sm">
+                        <span className="badge-info text-xs">
+                          {t(`approachTypes.${a.type}`, { defaultValue: a.type })}
+                        </span>
+                        <span className="font-mono tabular-nums text-slate-700 dark:text-slate-200">
+                          {a.airport || '—'}
+                          {a.runway ? ` · RWY ${a.runway}` : ''}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </dl>
+          </div>
+        )}
 
         {/* Remarks & Comments */}
         <div className="card">


### PR DESCRIPTION
## Summary

The Flight Detail page previously surfaced IFR time only as a single row in the Block Times card. All other instrument fields that the API already returns were silently hidden — pilots could not see them in the flight list or details:

- `actualInstrumentTime` (IMC)
- `simulatedInstrumentTime` (hood/foggles)
- `holds`
- `approachesCount`
- `approaches[]` — structured type / airport / runway (FAA §61.51(g)(3))
- `isIpc`

This PR adds a new **Instrument & Approaches** card that renders all of the above. The card is only shown when at least one of the fields is set, so VFR-only flights stay uncluttered. Structured approaches are rendered as badges with type + airport + runway, mirroring the EASA/FAA layout used in the PDF export.

IFR time is removed from the Block Times card to avoid duplication — it now lives in the new card alongside the related instrument data.

## i18n

Added `detail.instrumentAndApproaches` and `detail.yes` for en and de. All per-field labels (`fields.ifrTime`, `fields.actualInstrumentTime`, `fields.simulatedInstrumentTime`, `fields.holds`, `fields.approaches`, `fields.isIpc`) and the `approachTypes.*` keys already existed.

## Verification

- `npx vitest run` — 263/263 passing
- Manual smoke test: flight with IFR approaches now shows the new card; pure VFR flight does not.
