### PR TITLE
feat(maps): use dark basemap tiles in dark mode

### DIFF
--- a/src/pages/maps/MapPage.tsx
+++ b/src/pages/maps/MapPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MapContainer, TileLayer, Polyline, CircleMarker, Tooltip, useMap } from 'react-leaflet';
 import { useFlightRoutes, useAirportStats } from '../../hooks/useMaps';
+import { useTheme } from '../../hooks/useTheme';
 import { SkeletonList } from '../../components/ui/Skeleton';
 import { ErrorState } from '../../components/ui/ErrorState';
 import 'leaflet/dist/leaflet.css';
@@ -21,6 +22,8 @@ type MapView = 'routes' | 'heatmap';
 
 export default function MapPage() {
   const { t } = useTranslation('reports');
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === 'dark';
   const { data: routeData, isLoading: routesLoading } = useFlightRoutes();
   const { data: airportStats, isLoading: statsLoading } = useAirportStats();
   const [view, setView] = useState<MapView>('routes');
@@ -121,8 +124,17 @@ export default function MapPage() {
             style={{ height: '100%', width: '100%' }}
           >
             <TileLayer
-              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              key={isDark ? 'dark' : 'light'}
+              attribution={
+                isDark
+                  ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
+                  : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              }
+              url={
+                isDark
+                  ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+                  : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+              }
             />
 
             {allPositions.length > 0 && <FitBounds positions={allPositions} />}


### PR DESCRIPTION
## What

The flight map (`/maps`) now swaps tile providers based on the resolved theme so it doesn't blast a stark white rectangle into a dark UI.

- **Light mode** — OpenStreetMap standard tiles (unchanged)
- **Dark mode** — CARTO `dark_all` basemap (free, OSM-derived)

## How

`MapPage` reads `resolvedTheme` from `useTheme()` and picks the URL + attribution accordingly. A keyed `TileLayer` prop forces a clean remount when the theme toggles, so switching light/dark/system in the `ThemeSwitcher` updates the map immediately without a page reload.

Attribution credits CARTO in addition to OpenStreetMap when dark tiles are active, per [CARTO's basemap usage policy](https://github.com/CartoDB/basemap-styles#attribution).

## Verified

- `npx vitest run src/__tests__/maps/MapPage.test.tsx` — 9/9 passing
- `bash scripts/run-all-tests.sh` (Docker e2e) — 79 passed, 3 skipped