### PR TITLE
fix(maps): use CSS filter for dark map (Safari-compatible, drop CARTO)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -101,7 +101,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Referrer-Policy "no-referrer-when-downgrade" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:; manifest-src 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.tile.openstreetmap.org; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:; manifest-src 'self'" always;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -56,7 +56,7 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "no-referrer-when-downgrade" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.tile.openstreetmap.org https://*.basemaps.cartocdn.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:; manifest-src 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https://*.tile.openstreetmap.org; font-src 'self' https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; worker-src 'self' blob:; manifest-src 'self'" always;
 
         # Service Worker
         location /service-worker.js {

--- a/src/index.css
+++ b/src/index.css
@@ -129,6 +129,41 @@
     @apply outline-none ring-2 ring-blue-500 ring-offset-2;
   }
 
+  /* Dark-mode map: invert + hue-rotate the OSM tile pane in place of
+     a separate dark tile provider. This works identically across
+     Chrome, Firefox and Safari (no third-party CDN, no CSP changes,
+     no Safari ITP interactions) and survives offline tile caches.
+     Only the .leaflet-tile-pane is filtered so vector overlays
+     (Polylines, CircleMarkers) and tooltips keep their original
+     colours. */
+  .map-dark .leaflet-tile-pane {
+    filter: invert(1) hue-rotate(180deg) brightness(0.95) contrast(0.9) saturate(0.85);
+  }
+  /* Map container background — shown briefly before tiles paint and
+     in any tile gaps. Leaflet's default #ddd flashes white on dark. */
+  .map-dark .leaflet-container {
+    background: #0f172a; /* slate-900 */
+  }
+  /* Tone the built-in attribution + zoom controls so they don't burn
+     white against the dark basemap. These sit outside the tile pane
+     and aren't affected by the filter above. */
+  .map-dark .leaflet-control-attribution {
+    background: rgba(15, 23, 42, 0.8) !important;
+    color: #cbd5e1 !important;
+  }
+  .map-dark .leaflet-control-attribution a {
+    color: #93c5fd !important;
+  }
+  .map-dark .leaflet-bar a,
+  .map-dark .leaflet-bar a:hover {
+    background-color: #1e293b !important;
+    color: #e2e8f0 !important;
+    border-bottom-color: #334155 !important;
+  }
+  .map-dark .leaflet-bar a:hover {
+    background-color: #334155 !important;
+  }
+
   /* Body defaults — design system slate palette */
   body {
     @apply bg-slate-50 text-slate-800 font-sans antialiased;

--- a/src/pages/maps/MapPage.tsx
+++ b/src/pages/maps/MapPage.tsx
@@ -116,7 +116,10 @@ export default function MapPage() {
           </p>
         </div>
       ) : (
-        <div className="card p-0 overflow-hidden rounded-xl isolate" style={{ height: '65vh', minHeight: '400px' }}>
+        <div
+          className={`card p-0 overflow-hidden rounded-xl isolate ${isDark ? 'map-dark' : ''}`}
+          style={{ height: '65vh', minHeight: '400px' }}
+        >
           <MapContainer
             center={allPositions.length > 0 ? allPositions[0] : defaultCenter}
             zoom={5}
@@ -124,17 +127,8 @@ export default function MapPage() {
             style={{ height: '100%', width: '100%' }}
           >
             <TileLayer
-              key={isDark ? 'dark' : 'light'}
-              attribution={
-                isDark
-                  ? '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/attributions">CARTO</a>'
-                  : '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-              }
-              url={
-                isDark
-                  ? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-                  : 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
-              }
+              attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
 
             {allPositions.length > 0 && <FitBounds positions={allPositions} />}


### PR DESCRIPTION
## What

PR #58 swapped the dark-mode map to CARTO's `dark_all` basemap. That works in Chrome but renders **grey in Safari** — most likely Safari's Intelligent Tracking Prevention treating `*.basemaps.cartocdn.com` as a third-party tracker and silently blocking the tile requests.

This PR switches to the well-known CSS-filter technique instead:

```css
.map-dark .leaflet-tile-pane {
  filter: invert(1) hue-rotate(180deg) brightness(0.95) contrast(0.9) saturate(0.85);
}
```

## Why this is nicer

- **Same tile provider for both themes** (OpenStreetMap) — no extra CDN, no extra CSP entry, no third-party-cookie / ITP edge cases.
- **Works identically in Chromium, Firefox and WebKit/Safari.**
- Filter is scoped to `.leaflet-tile-pane` so vector overlays (Polylines, CircleMarkers, tooltips) keep their original colours.
- **Survives the offline tile cache** — the same cached tiles render correctly in either theme.

Also styled the Leaflet container background, attribution and zoom controls for dark mode so they don't burn white against the inverted tiles.

## CSP cleanup

Removed `https://*.basemaps.cartocdn.com` from `img-src` in both `nginx.conf` and `docker-entrypoint.sh` — no longer needed.

## Verified

- `npx vitest run src/__tests__/maps/MapPage.test.tsx` — 9/9 passing