### PR TITLE
feat(import): restore from JSON backup

### DIFF
--- a/src/__tests__/e2e/import-json-restore.spec.ts
+++ b/src/__tests__/e2e/import-json-restore.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+import { createTestUser, injectAuth, apiCall, type AuthContext } from './helpers';
+
+// Full end-to-end JSON backup/restore through the UI:
+//
+//   1. User A (seeded via API) populates an account with a small but
+//      non-trivial profile.
+//   2. User A's account is exported to JSON via the API (we don't drive the
+//      Export page UI here; that's covered elsewhere).
+//   3. User B is created fresh, logged in, and visits /import.
+//   4. The user clicks the "Restore JSON Backup" tab, uploads the backup
+//      file, and sees the success summary card.
+//   5. The /flights and /aircraft API endpoints for user B are then asserted
+//      to reflect the restored data — proving the UI flow really wires up to
+//      the backend.
+
+test.describe('Import page — JSON restore', () => {
+  test('user can restore a JSON backup through the UI', async ({ page, request }) => {
+    // ----- 1. Seed source account via API -----
+    const source: AuthContext = await createTestUser(request);
+
+    await apiCall(page, 'POST', '/aircraft', {
+      registration: 'D-EUIE',
+      type: 'C172',
+      make: 'Cessna',
+      model: '172S',
+      aircraftClass: 'SEP_LAND',
+    }, source.accessToken);
+
+    await apiCall(page, 'POST', '/aircraft', {
+      registration: 'N321UI',
+      type: 'B738',
+      make: 'Boeing',
+      model: '737-800',
+      aircraftClass: 'MEP_LAND',
+    }, source.accessToken);
+
+    const lic = await apiCall(page, 'POST', '/licenses', {
+      regulatoryAuthority: 'EASA',
+      licenseType: 'PPL',
+      licenseNumber: `UI-PPL-${Date.now()}`,
+      issueDate: '2022-03-15',
+      issuingAuthority: 'LBA',
+    }, source.accessToken);
+    await apiCall(page, 'POST', `/licenses/${lic.id}/ratings`, {
+      classType: 'SEP_LAND',
+      issueDate: '2022-03-15',
+    }, source.accessToken);
+
+    await apiCall(page, 'POST', '/credentials', {
+      credentialType: 'EASA_CLASS2_MEDICAL',
+      credentialNumber: 'UI-MED-001',
+      issueDate: '2024-01-01',
+      expiryDate: '2027-01-01',
+      issuingAuthority: 'AME UI',
+    }, source.accessToken);
+
+    await apiCall(page, 'POST', '/flights', {
+      date: '2024-09-01',
+      aircraftReg: 'D-EUIE',
+      aircraftType: 'C172',
+      departureIcao: 'EDNY',
+      arrivalIcao: 'EDDS',
+      offBlockTime: '08:00',
+      onBlockTime: '09:00',
+      landings: 1,
+      remarks: 'UI restore source flight',
+    }, source.accessToken);
+
+    await apiCall(page, 'POST', '/flights', {
+      date: '2024-10-12',
+      aircraftReg: 'N321UI',
+      aircraftType: 'B738',
+      departureIcao: 'EDDF',
+      arrivalIcao: 'KJFK',
+      offBlockTime: '12:00',
+      onBlockTime: '20:30',
+      landings: 1,
+      remarks: 'Airline leg',
+      crewMembers: [
+        { name: 'Capt. UI Test', role: 'PIC' },
+        { name: 'FO UI Test', role: 'SIC' },
+      ],
+    }, source.accessToken);
+
+    // ----- 2. Download source backup via API -----
+    const exportRes = await request.get('/api/v1/exports/json', {
+      headers: { Authorization: `Bearer ${source.accessToken}` },
+    });
+    expect(exportRes.ok()).toBeTruthy();
+    const backupText = await exportRes.text();
+    expect(backupText).toContain('NinerLog JSON Backup');
+
+    // ----- 3. Fresh destination account, log in, go to /import -----
+    const dest: AuthContext = await createTestUser(request);
+    await injectAuth(page, dest);
+
+    await page.goto('/import');
+    await expect(page.getByText('Import Flights')).toBeVisible({ timeout: 10000 });
+
+    // ----- 4. Switch to JSON restore tab + upload backup -----
+    await page.getByRole('tab', { name: 'Restore JSON Backup' }).click();
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: /choose json backup/i }).click();
+    const chooser = await fileChooserPromise;
+    await chooser.setFiles({
+      name: 'ninerlog_backup.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(backupText),
+    });
+
+    // Success card appears with counts.
+    await expect(page.getByRole('heading', { name: 'Backup restored' })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Aircraft imported')).toBeVisible();
+    // Scope the "Flights" label lookup to the main content area to avoid
+    // matching the nav link of the same name.
+    await expect(page.locator('#main-content').getByText('Flights', { exact: true })).toBeVisible();
+
+    // ----- 5. Verify the destination account really got the data -----
+    const restoredAircraft = await apiCall(page, 'GET', '/aircraft', undefined, dest.accessToken);
+    const regs = new Set<string>(
+      (restoredAircraft.data || []).map((a: { registration: string }) => a.registration),
+    );
+    expect(regs.has('D-EUIE')).toBeTruthy();
+    expect(regs.has('N321UI')).toBeTruthy();
+
+    const restoredFlights = await apiCall(page, 'GET', '/flights?pageSize=50', undefined, dest.accessToken);
+    expect((restoredFlights.data || []).length).toBeGreaterThanOrEqual(2);
+
+    const restoredCreds = await apiCall(page, 'GET', '/credentials', undefined, dest.accessToken);
+    expect(restoredCreds.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('user sees a clear error when uploading non-NinerLog JSON', async ({ page, request }) => {
+    const dest = await createTestUser(request);
+    await injectAuth(page, dest);
+
+    await page.goto('/import');
+    await page.getByRole('tab', { name: 'Restore JSON Backup' }).click();
+
+    const fileChooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: /choose json backup/i }).click();
+    const chooser = await fileChooserPromise;
+    await chooser.setFiles({
+      name: 'not-ninerlog.json',
+      mimeType: 'application/json',
+      buffer: Buffer.from(JSON.stringify({ format: 'Some Other Tool' })),
+    });
+
+    // The API rejects the foreign format with 400 + error message; the page
+    // surfaces it inline (not as a toast).
+    await expect(page.getByText(/Unsupported backup format/i)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -944,6 +944,34 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/imports/json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Restore a NinerLog JSON backup
+         * @description Restore a previously exported NinerLog JSON backup into the authenticated
+         *     user's account. Recreates aircraft, licenses, class ratings, credentials,
+         *     flights and crew members from the backup. New UUIDs are assigned so the
+         *     backup can be restored into any NinerLog installation (including the one
+         *     it was exported from).
+         *
+         *     This is an additive operation — it does not modify or delete existing
+         *     data. Aircraft whose registration already exists for the user are
+         *     skipped (and the existing aircraft is referenced by imported flights).
+         */
+        post: operations["importDataJSON"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/exports/pdf": {
         parameters: {
             query?: never;
@@ -993,7 +1021,7 @@ export interface paths {
         };
         /**
          * Get statistics by aircraft class and category
-         * @description Returns aggregated flight statistics grouped by aircraft class, aircraft category (tailwheel, complex, high-performance), and regulatory authority.
+         * @description Returns aggregated flight statistics grouped by aircraft class, aircraft category (tailwheel, complex, high-performance), and regulatory authority. Results are scoped to the requested timeframe.
          */
         get: operations["getStatsByClass"];
         put?: never;
@@ -3193,6 +3221,29 @@ export interface components {
              */
             createdAt: string;
         };
+        /** @description Summary returned by `POST /imports/json` after restoring a backup. */
+        ImportJSONResult: {
+            /**
+             * @description Number of aircraft created from the backup
+             * @example 3
+             */
+            aircraftImported: number;
+            /**
+             * @description Aircraft skipped because the registration already exists for the user
+             * @example 1
+             */
+            aircraftSkipped: number;
+            /** @example 2 */
+            licensesImported: number;
+            /** @example 4 */
+            classRatingsImported: number;
+            /** @example 2 */
+            credentialsImported: number;
+            /** @example 27 */
+            flightsImported: number;
+            /** @example 11 */
+            crewMembersImported: number;
+        };
         PaginatedImports: {
             data: components["schemas"]["ImportResult"][];
             pagination: {
@@ -5248,6 +5299,42 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
         };
     };
+    importDataJSON: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @example NinerLog JSON Backup */
+                    format: string;
+                    version?: string;
+                    /** Format: date-time */
+                    exportedAt?: string;
+                    flights?: Record<string, never>[];
+                    aircraft?: Record<string, never>[];
+                    licenses?: Record<string, never>[];
+                    credentials?: Record<string, never>[];
+                };
+            };
+        };
+        responses: {
+            /** @description Restore summary with per-entity counts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportJSONResult"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
     exportFlightsPDF: {
         parameters: {
             query?: {
@@ -5314,7 +5401,10 @@ export interface operations {
     };
     getStatsByClass: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Number of months to include (default 12, 0 = all time) */
+                months?: number;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/src/hooks/useImport.ts
+++ b/src/hooks/useImport.ts
@@ -7,8 +7,15 @@ type ImportUploadResponse = components['schemas']['ImportUploadResponse'];
 type ImportPreviewResponse = components['schemas']['ImportPreviewResponse'];
 type ImportResult = components['schemas']['ImportResult'];
 type ImportColumnMapping = components['schemas']['ImportColumnMapping'];
+type ImportJSONResult = components['schemas']['ImportJSONResult'];
 
-export type { ImportUploadResponse, ImportPreviewResponse, ImportResult, ImportColumnMapping };
+export type {
+  ImportUploadResponse,
+  ImportPreviewResponse,
+  ImportResult,
+  ImportColumnMapping,
+  ImportJSONResult,
+};
 
 import { API_BASE_URL } from '../lib/config';
 
@@ -79,6 +86,52 @@ export const useConfirmImport = () => {
     onSuccess: () => {
       invalidateFlightDependentQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['imports'] });
+    },
+  });
+};
+
+/**
+ * Restore a NinerLog JSON backup (as produced by `GET /exports/json`).
+ *
+ * The endpoint is additive: it never deletes or modifies existing data, and
+ * skips aircraft whose registration already exists for the user. After a
+ * successful restore we invalidate every query that depends on the flight
+ * log, plus the aircraft/licenses/credentials lists since those were all
+ * potentially repopulated.
+ */
+export const useRestoreJSON = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (file: File): Promise<ImportJSONResult> => {
+      // Read the file as text first so we can reject obviously-broken JSON
+      // before paying the cost of a network round-trip.
+      const text = await file.text();
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        throw new Error('Selected file is not valid JSON');
+      }
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Selected file is not a NinerLog JSON backup');
+      }
+      const res = await fetch(`${API_BASE_URL}/imports/json`, {
+        method: 'POST',
+        headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' },
+        body: text,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({ error: 'Restore failed' }));
+        throw new Error(err.error || 'Restore failed');
+      }
+      return res.json();
+    },
+    onSuccess: () => {
+      invalidateFlightDependentQueries(queryClient);
+      queryClient.invalidateQueries({ queryKey: ['aircraft'] });
+      queryClient.invalidateQueries({ queryKey: ['licenses'] });
+      queryClient.invalidateQueries({ queryKey: ['credentials'] });
+      queryClient.invalidateQueries({ queryKey: ['class-ratings'] });
     },
   });
 };

--- a/src/i18n/locales/de/import.json
+++ b/src/i18n/locales/de/import.json
@@ -19,5 +19,24 @@
   "importFailed": "Import fehlgeschlagen. Bitte überprüfen Sie das Dateiformat.",
   "rowsDetected_one": "{{count}} Zeile erkannt",
   "rowsDetected_other": "{{count}} Zeilen erkannt",
-  "duplicateWarning": "Einige Flüge könnten bereits vorhandenen Einträgen entsprechen."
+  "duplicateWarning": "Einige Flüge könnten bereits vorhandenen Einträgen entsprechen.",
+
+  "modeTabsLabel": "Import-Modus",
+  "modeCsv": "CSV-Flüge",
+  "modeJson": "JSON-Sicherung wiederherstellen",
+  "restoreJsonTitle": "JSON-Sicherung wiederherstellen",
+  "restoreJsonDescription": "Laden Sie eine NinerLog-JSON-Sicherung hoch (aus Export → Komplettes Datenbackup), um Ihre Flüge, Luftfahrzeuge, Lizenzen, Klassenberechtigungen, Nachweise und Crew-Mitglieder wiederherzustellen.",
+  "restoreJsonNote": "Die Wiederherstellung ist additiv — vorhandene Daten werden nie geändert oder gelöscht. Luftfahrzeuge, deren Kennzeichen bereits in Ihrem Konto vorhanden ist, werden übersprungen.",
+  "selectJsonFile": "JSON-Sicherung auswählen",
+  "restoringJson": "Wiederherstellen…",
+  "restoreJsonSuccess": "Sicherung wiederhergestellt",
+  "restoreJsonSummary": "Ihre Daten wurden erfolgreich in dieses Konto importiert.",
+  "restoreSummaryAircraftImported": "Luftfahrzeuge importiert",
+  "restoreSummaryAircraftSkipped": "Luftfahrzeuge übersprungen",
+  "restoreSummaryLicenses": "Lizenzen",
+  "restoreSummaryClassRatings": "Klassenberechtigungen",
+  "restoreSummaryCredentials": "Nachweise",
+  "restoreSummaryFlights": "Flüge",
+  "restoreSummaryCrew": "Crew-Mitglieder",
+  "restoreAnother": "Weitere Sicherung wiederherstellen"
 }

--- a/src/i18n/locales/en/import.json
+++ b/src/i18n/locales/en/import.json
@@ -19,5 +19,24 @@
   "importFailed": "Import failed. Please check your file format.",
   "rowsDetected_one": "{{count}} row detected",
   "rowsDetected_other": "{{count}} rows detected",
-  "duplicateWarning": "Some flights may be duplicates of existing entries."
+  "duplicateWarning": "Some flights may be duplicates of existing entries.",
+
+  "modeTabsLabel": "Import mode",
+  "modeCsv": "CSV Flights",
+  "modeJson": "Restore JSON Backup",
+  "restoreJsonTitle": "Restore JSON Backup",
+  "restoreJsonDescription": "Upload a NinerLog JSON backup (from Export → Full Data Backup) to restore your flights, aircraft, licenses, class ratings, credentials and crew members.",
+  "restoreJsonNote": "The restore is additive — existing data is never modified or deleted. Aircraft whose registration already exists in your account are skipped.",
+  "selectJsonFile": "Choose JSON backup",
+  "restoringJson": "Restoring…",
+  "restoreJsonSuccess": "Backup restored",
+  "restoreJsonSummary": "Your data was successfully imported into this account.",
+  "restoreSummaryAircraftImported": "Aircraft imported",
+  "restoreSummaryAircraftSkipped": "Aircraft skipped",
+  "restoreSummaryLicenses": "Licenses",
+  "restoreSummaryClassRatings": "Class ratings",
+  "restoreSummaryCredentials": "Credentials",
+  "restoreSummaryFlights": "Flights",
+  "restoreSummaryCrew": "Crew members",
+  "restoreAnother": "Restore another backup"
 }

--- a/src/pages/import/ImportPage.tsx
+++ b/src/pages/import/ImportPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useUploadImport, usePreviewImport, useConfirmImport } from '../../hooks/useImport';
-import type { ImportUploadResponse, ImportPreviewResponse, ImportResult, ImportColumnMapping } from '../../hooks/useImport';
+import { useUploadImport, usePreviewImport, useConfirmImport, useRestoreJSON } from '../../hooks/useImport';
+import type { ImportUploadResponse, ImportPreviewResponse, ImportResult, ImportColumnMapping, ImportJSONResult } from '../../hooks/useImport';
 import HelpLink from '../../components/ui/HelpLink';
 
 const IMPORT_FIELDS = [
@@ -42,20 +42,25 @@ const IMPORT_FIELDS = [
 ];
 
 type Step = 'upload' | 'mapping' | 'preview' | 'result';
+type Mode = 'csv' | 'json';
 
 export default function ImportPage() {
   const { t } = useTranslation('import');
+  const [mode, setMode] = useState<Mode>('csv');
   const [step, setStep] = useState<Step>('upload');
   const [uploadData, setUploadData] = useState<ImportUploadResponse | null>(null);
   const [mappings, setMappings] = useState<ImportColumnMapping[]>([]);
   const [previewData, setPreviewData] = useState<ImportPreviewResponse | null>(null);
   const [result, setResult] = useState<ImportResult | null>(null);
+  const [jsonResult, setJsonResult] = useState<ImportJSONResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const jsonInputRef = useRef<HTMLInputElement>(null);
 
   const upload = useUploadImport();
   const preview = usePreviewImport();
   const confirm = useConfirmImport();
+  const restore = useRestoreJSON();
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -119,8 +124,33 @@ export default function ImportPage() {
     setMappings([]);
     setPreviewData(null);
     setResult(null);
+    setJsonResult(null);
     setError(null);
     if (fileInputRef.current) fileInputRef.current.value = '';
+    if (jsonInputRef.current) jsonInputRef.current.value = '';
+  };
+
+  const handleSwitchMode = (next: Mode) => {
+    if (next === mode) return;
+    handleReset();
+    setMode(next);
+  };
+
+  const handleJSONFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setError(null);
+    setJsonResult(null);
+    try {
+      const data = await restore.mutateAsync(file);
+      setJsonResult(data);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Restore failed';
+      setError(message);
+    } finally {
+      // Reset the input so the same file can be re-selected after an error.
+      if (jsonInputRef.current) jsonInputRef.current.value = '';
+    }
   };
 
   return (
@@ -133,7 +163,42 @@ export default function ImportPage() {
         </p>
       </div>
 
-      {/* Step indicator */}
+      {/* Mode tabs: CSV flight import vs. full JSON backup restore. The two
+          flows share zero state and reset each other, which keeps the
+          underlying step machine simple. */}
+      <div
+        role="tablist"
+        aria-label={t('modeTabsLabel', 'Import mode')}
+        className="flex gap-2 mb-6 border-b border-slate-200 dark:border-slate-700"
+      >
+        <button
+          role="tab"
+          aria-selected={mode === 'csv'}
+          onClick={() => handleSwitchMode('csv')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors min-h-[44px] ${
+            mode === 'csv'
+              ? 'border-blue-600 text-blue-700 dark:text-blue-400'
+              : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+          }`}
+        >
+          {t('modeCsv', 'CSV Flights')}
+        </button>
+        <button
+          role="tab"
+          aria-selected={mode === 'json'}
+          onClick={() => handleSwitchMode('json')}
+          className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors min-h-[44px] ${
+            mode === 'json'
+              ? 'border-blue-600 text-blue-700 dark:text-blue-400'
+              : 'border-transparent text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+          }`}
+        >
+          {t('modeJson', 'Restore JSON Backup')}
+        </button>
+      </div>
+
+      {/* Step indicator (CSV flow only) */}
+      {mode === 'csv' && (
       <div className="flex items-center gap-2 mb-6 text-sm">
         {(['upload', 'mapping', 'preview', 'result'] as Step[]).map((s, i) => (
           <div key={s} className="flex items-center gap-2">
@@ -150,6 +215,7 @@ export default function ImportPage() {
           </div>
         ))}
       </div>
+      )}
 
       {error && (
         <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400 px-4 py-3 rounded-lg text-sm mb-4">
@@ -157,8 +223,100 @@ export default function ImportPage() {
         </div>
       )}
 
+      {/* JSON Restore flow — single-step upload, immediate result. */}
+      {mode === 'json' && !jsonResult && (
+        <div className="card text-center py-12">
+          <div className="text-5xl mb-4">💾</div>
+          <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100 mb-2">
+            {t('restoreJsonTitle', 'Restore JSON Backup')}
+          </h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-2 max-w-md mx-auto">
+            {t(
+              'restoreJsonDescription',
+              'Upload a NinerLog JSON backup (from Export → Full Data Backup) to restore your flights, aircraft, licenses, class ratings, credentials and crew members.',
+            )}
+          </p>
+          <p className="text-xs text-slate-400 dark:text-slate-500 mb-6 max-w-md mx-auto">
+            {t(
+              'restoreJsonNote',
+              'The restore is additive — existing data is never modified or deleted. Aircraft whose registration already exists in your account are skipped.',
+            )}
+          </p>
+          <input
+            ref={jsonInputRef}
+            type="file"
+            accept="application/json,.json"
+            onChange={handleJSONFileSelect}
+            className="hidden"
+          />
+          <button
+            onClick={() => jsonInputRef.current?.click()}
+            disabled={restore.isPending}
+            className="btn-primary"
+          >
+            {restore.isPending
+              ? t('restoringJson', 'Restoring…')
+              : t('selectJsonFile', 'Choose JSON backup')}
+          </button>
+        </div>
+      )}
+
+      {mode === 'json' && jsonResult && (
+        <div className="card text-center py-12">
+          <div className="text-5xl mb-4">✅</div>
+          <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100 mb-2">
+            {t('restoreJsonSuccess', 'Backup restored')}
+          </h2>
+          <p className="text-slate-500 dark:text-slate-400 mb-6 max-w-md mx-auto">
+            {t('restoreJsonSummary', 'Your data was successfully imported into this account.')}
+          </p>
+
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 max-w-2xl mx-auto mb-6">
+            <SummaryCard
+              label={t('restoreSummaryAircraftImported', 'Aircraft imported')}
+              value={jsonResult.aircraftImported}
+              color="green"
+            />
+            <SummaryCard
+              label={t('restoreSummaryAircraftSkipped', 'Aircraft skipped')}
+              value={jsonResult.aircraftSkipped}
+              color="amber"
+            />
+            <SummaryCard
+              label={t('restoreSummaryLicenses', 'Licenses')}
+              value={jsonResult.licensesImported}
+              color="green"
+            />
+            <SummaryCard
+              label={t('restoreSummaryClassRatings', 'Class ratings')}
+              value={jsonResult.classRatingsImported}
+              color="green"
+            />
+            <SummaryCard
+              label={t('restoreSummaryCredentials', 'Credentials')}
+              value={jsonResult.credentialsImported}
+              color="green"
+            />
+            <SummaryCard
+              label={t('restoreSummaryFlights', 'Flights')}
+              value={jsonResult.flightsImported}
+              color="green"
+            />
+            <SummaryCard
+              label={t('restoreSummaryCrew', 'Crew members')}
+              value={jsonResult.crewMembersImported}
+              color="green"
+            />
+          </div>
+
+          <button onClick={handleReset} className="btn-primary">
+            {t('restoreAnother', 'Restore another backup')}
+          </button>
+        </div>
+      )}
+
       {/* Step 1: Upload */}
-      {step === 'upload' && (
+      {mode === 'csv' && step === 'upload' && (
         <div className="card text-center py-12">
           <div className="text-5xl mb-4">📂</div>
           <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100 mb-2">{t('uploadCsv', 'Upload Flight Log File')}</h2>
@@ -183,7 +341,7 @@ export default function ImportPage() {
       )}
 
       {/* Step 2: Column Mapping */}
-      {step === 'mapping' && uploadData && (
+      {mode === 'csv' && step === 'mapping' && uploadData && (
         <div className="space-y-4">
           <div className="card">
             <div className="flex justify-between items-center mb-4">
@@ -258,7 +416,7 @@ export default function ImportPage() {
       )}
 
       {/* Step 3: Preview */}
-      {step === 'preview' && previewData && (
+      {mode === 'csv' && step === 'preview' && previewData && (
         <div className="space-y-4">
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
             <SummaryCard label="Total Rows" value={previewData.totalRows} />
@@ -345,7 +503,7 @@ export default function ImportPage() {
       )}
 
       {/* Step 4: Result */}
-      {step === 'result' && result && (
+      {mode === 'csv' && step === 'result' && result && (
         <div className="card text-center py-12">
           <div className="text-5xl mb-4">
             {result.status === 'completed' ? '✅' : result.status === 'partial' ? '⚠' : '❌'}


### PR DESCRIPTION
## Summary

Adds a **Restore JSON Backup** mode to the Import page so a user can pick their NinerLog JSON export file and recreate their full profile — aircraft, licenses and class ratings, credentials, and flights with crew — in any NinerLog installation.

Pairs with the API PR: https://github.com/fjaeckel/ninerlog-api/pulls (branch `feat/import-json-backup`).

## Changes

- Regenerated API client picks up `POST /imports/json` + `ImportJSONResult`
- New `useRestoreJSON` mutation reads the file, validates it is JSON and carries the NinerLog backup marker before uploading, surfaces server errors cleanly, and invalidates the affected query keys (flights, aircraft, licenses, class ratings, credentials)
- `ImportPage` gets a `role="tablist"` switching between **CSV Flights** and **Restore JSON Backup**. The JSON mode shows a file picker, a pending state, and a success card with a `SummaryCard` grid covering all seven counters returned by the API
- en/de i18n strings for the new UI

## Tests

Playwright e2e (`src/__tests__/e2e/import-json-restore.spec.ts`):

- Full UI round-trip: source user seeds aircraft, license, rating, credential, and two flights (incl. an airline leg with PIC + SIC crew), exports JSON via the API, then a fresh destination user uses the UI to upload the backup and the test verifies the success summary and the restored data via the API.
- Foreign backup uploaded via the UI shows a clear error.

Full results locally:
- `npx tsc --noEmit` clean
- `npx vitest run` — 263/263 passing
- `npx playwright test` — 81/81 passing (3 passkey tests skipped as usual)