### PR TITLE
feat(frontend): cloud backup settings page (S3 provider)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,6 +37,8 @@ services:
         condition: service_healthy
       api-test:
         condition: service_healthy
+      minio-test-init:
+        condition: service_completed_successfully
     networks:
       - test-network
 
@@ -133,12 +135,51 @@ services:
       WEBAUTHN_RP_ID: "app.ninerlog.test"
       WEBAUTHN_RP_NAME: "NinerLog E2E"
       WEBAUTHN_RP_ORIGINS: "http://app.ninerlog.test:5173,http://localhost:5174,http://localhost:5173"
+      # Cloud backups
+      BACKUP_CREDENTIALS_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
+      E2E_MINIO_ENDPOINT: "http://minio-test:9000"
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 10s
+    profiles:
+      - e2e
+    networks:
+      - test-network
+
+  minio-test:
+    image: minio/minio:latest
+    container_name: ninerlog-frontend-test-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    expose:
+      - "9000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/ready || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    profiles:
+      - e2e
+    networks:
+      - test-network
+
+  minio-test-init:
+    image: minio/mc:latest
+    container_name: ninerlog-frontend-test-minio-init
+    depends_on:
+      minio-test:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio-test:9000 minioadmin minioadmin &&
+        mc mb --ignore-existing local/ninerlog-backups &&
+        exit 0
+      "
     profiles:
       - e2e
     networks:

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -28,8 +28,9 @@ else
     echo "=================================================="
     echo ""
     
-    echo "🐳 Starting test environment (DB + MailPit + API + Frontend)..."
-    docker compose -f docker-compose.test.yml --profile e2e up -d --build postgres-test mailpit-test api-test frontend-dev
+    echo "🐳 Starting test environment (DB + MailPit + API + Frontend + MinIO)..."
+    docker compose -f docker-compose.test.yml --profile e2e up -d --build postgres-test mailpit-test minio-test api-test frontend-dev
+    docker compose -f docker-compose.test.yml --profile e2e run --rm minio-test-init || true
     
     echo "⏳ Waiting for services to be healthy..."
     sleep 10

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const ReportsPage = lazy(() => import('./pages/reports/ReportsPage'));
 const MapPage = lazy(() => import('./pages/maps/MapPage'));
 const ImportPage = lazy(() => import('./pages/import/ImportPage'));
 const ExportPage = lazy(() => import('./pages/export/ExportPage'));
+const BackupsPage = lazy(() => import('./pages/backups/BackupsPage'));
 const CurrencyPage = lazy(() => import('./pages/currency/CurrencyPage'));
 const AdminPage = lazy(() => import('./pages/admin/AdminPage'));
 const HelpPage = lazy(() => import('./pages/help/HelpPage'));
@@ -75,6 +76,7 @@ function App() {
           <Route path="/map" element={isAuthenticated ? <MapPage /> : <Navigate to="/login" />} />
           <Route path="/import" element={isAuthenticated ? <ImportPage /> : <Navigate to="/login" />} />
           <Route path="/export" element={isAuthenticated ? <ExportPage /> : <Navigate to="/login" />} />
+          <Route path="/backups" element={isAuthenticated ? <BackupsPage /> : <Navigate to="/login" />} />
           <Route path="/currency" element={isAuthenticated ? <CurrencyPage /> : <Navigate to="/login" />} />
           <Route path="/admin" element={isAuthenticated ? <AdminPage /> : <Navigate to="/login" />} />
           <Route path="/help" element={isAuthenticated ? <HelpPage /> : <Navigate to="/login" />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ const ReportsPage = lazy(() => import('./pages/reports/ReportsPage'));
 const MapPage = lazy(() => import('./pages/maps/MapPage'));
 const ImportPage = lazy(() => import('./pages/import/ImportPage'));
 const ExportPage = lazy(() => import('./pages/export/ExportPage'));
-const BackupsPage = lazy(() => import('./pages/backups/BackupsPage'));
 const CurrencyPage = lazy(() => import('./pages/currency/CurrencyPage'));
 const AdminPage = lazy(() => import('./pages/admin/AdminPage'));
 const HelpPage = lazy(() => import('./pages/help/HelpPage'));
@@ -76,7 +75,7 @@ function App() {
           <Route path="/map" element={isAuthenticated ? <MapPage /> : <Navigate to="/login" />} />
           <Route path="/import" element={isAuthenticated ? <ImportPage /> : <Navigate to="/login" />} />
           <Route path="/export" element={isAuthenticated ? <ExportPage /> : <Navigate to="/login" />} />
-          <Route path="/backups" element={isAuthenticated ? <BackupsPage /> : <Navigate to="/login" />} />
+          <Route path="/backups" element={<Navigate to="/profile" replace />} />
           <Route path="/currency" element={isAuthenticated ? <CurrencyPage /> : <Navigate to="/login" />} />
           <Route path="/admin" element={isAuthenticated ? <AdminPage /> : <Navigate to="/login" />} />
           <Route path="/help" element={isAuthenticated ? <HelpPage /> : <Navigate to="/login" />} />

--- a/src/__tests__/backups/BackupDestinationForm.test.tsx
+++ b/src/__tests__/backups/BackupDestinationForm.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import BackupDestinationForm from '../../components/backups/BackupDestinationForm';
+import * as useBackupsHook from '../../hooks/useBackups';
+
+const renderWithProviders = (ui: React.ReactElement) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+};
+
+const s3Provider = {
+  name: 's3',
+  displayName: 'Amazon S3',
+  description: 'S3-compatible buckets',
+  configSchema: {
+    fields: [
+      { name: 'bucket', label: 'Bucket', type: 'string', required: true },
+      { name: 'region', label: 'Region', type: 'region', required: true },
+      { name: 'prefix', label: 'Prefix', type: 'string', required: false },
+      { name: 'endpoint', label: 'Endpoint URL', type: 'url', required: false },
+    ],
+  },
+  credentialSchema: {
+    fields: [
+      { name: 'access_key_id', label: 'Access key ID', type: 'string', required: true },
+      { name: 'secret_access_key', label: 'Secret access key', type: 'password', required: true },
+    ],
+  },
+};
+
+describe('BackupDestinationForm', () => {
+  const mockCreate = { mutateAsync: vi.fn(), isPending: false };
+  const mockUpdate = { mutateAsync: vi.fn(), isPending: false };
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(useBackupsHook, 'useBackupProviders').mockReturnValue({
+      data: [s3Provider],
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.spyOn(useBackupsHook, 'useCreateBackupDestination').mockReturnValue(mockCreate as any);
+    vi.spyOn(useBackupsHook, 'useUpdateBackupDestination').mockReturnValue(mockUpdate as any);
+  });
+
+  it('renders provider fields dynamically from the schema', async () => {
+    renderWithProviders(<BackupDestinationForm onClose={onClose} />);
+
+    await waitFor(() => expect(screen.getByLabelText(/display name/i)).toBeInTheDocument());
+
+    expect(screen.getByLabelText(/^Bucket/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Region/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Prefix$/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Endpoint URL/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Access key ID/)).toBeInTheDocument();
+
+    const secret = screen.getByLabelText(/Secret access key/);
+    expect(secret).toHaveAttribute('type', 'password');
+  });
+
+  it('submits a new destination with config and credentials', async () => {
+    const user = userEvent.setup();
+    mockCreate.mutateAsync.mockResolvedValueOnce({});
+
+    renderWithProviders(<BackupDestinationForm onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/display name/i), 'My S3 backup');
+    await user.type(screen.getByLabelText(/^Bucket/), 'my-bucket');
+    await user.type(screen.getByLabelText(/^Region/), 'us-east-1');
+    await user.type(screen.getByLabelText(/Access key ID/), 'AKIAEXAMPLE');
+    await user.type(screen.getByLabelText(/Secret access key/), 'sekret');
+
+    await user.click(screen.getByRole('button', { name: /create destination/i }));
+
+    await waitFor(() => expect(mockCreate.mutateAsync).toHaveBeenCalledTimes(1));
+
+    const payload = mockCreate.mutateAsync.mock.calls[0][0];
+    expect(payload.provider).toBe('s3');
+    expect(payload.displayName).toBe('My S3 backup');
+    expect(payload.config).toEqual({ bucket: 'my-bucket', region: 'us-east-1' });
+    expect(payload.credentials).toEqual({
+      access_key_id: 'AKIAEXAMPLE',
+      secret_access_key: 'sekret',
+    });
+    expect(payload.schedule).toBe('manual');
+    expect(payload.enabled).toBe(true);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows day-of-week selector only when weekly schedule is chosen', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<BackupDestinationForm onClose={onClose} />);
+
+    expect(screen.queryByLabelText(/day of week/i)).not.toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText(/cadence/i), 'weekly');
+
+    expect(screen.getByLabelText(/day of week/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/day of month/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/e2e/backups.spec.ts
+++ b/src/__tests__/e2e/backups.spec.ts
@@ -24,8 +24,9 @@ test.describe('Cloud Backups', () => {
       throw new Error(`Backups endpoint not reachable: ${probe.status()} ${await probe.text()}`);
     }
 
-    await page.goto('/backups');
-    await expect(page.getByRole('heading', { name: /cloud backups/i })).toBeVisible();
+    // Cloud backups now live under Profile Settings → Cloud Backups tab.
+    await page.goto('/profile');
+    await page.getByRole('button', { name: /cloud backups/i }).click();
     await expect(page.getByText(/no backup destinations/i)).toBeVisible();
 
     await page.getByRole('button', { name: /add your first destination|add destination/i }).first().click();

--- a/src/__tests__/e2e/backups.spec.ts
+++ b/src/__tests__/e2e/backups.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test';
+import { registerAndLogin } from './helpers';
+
+// Cloud backup settings flow. Requires the API to be running with
+// BACKUP_CREDENTIALS_KEY set and a reachable MinIO service. In the docker
+// e2e environment (docker-compose.test.yml) this is provided as
+// "minio-test:9000" and a pre-created bucket "ninerlog-backups".
+//
+// When running locally without those services, this suite is auto-skipped.
+
+const MINIO_ENDPOINT = process.env.E2E_MINIO_ENDPOINT || 'http://minio-test:9000';
+const MINIO_BUCKET = process.env.E2E_MINIO_BUCKET || 'ninerlog-backups';
+
+test.describe('Cloud Backups', () => {
+  test('create, test, run, view history, and delete an S3 destination', async ({ page, request }) => {
+    const auth = await registerAndLogin(page);
+
+    // Skip if the API hasn't enabled cloud backups (no BACKUP_CREDENTIALS_KEY)
+    const probe = await request.get('/api/v1/backups/providers', {
+      headers: { Authorization: `Bearer ${auth.accessToken}` },
+    });
+    test.skip(probe.status() === 503, 'Cloud backups not enabled on the API');
+    if (!probe.ok()) {
+      throw new Error(`Backups endpoint not reachable: ${probe.status()} ${await probe.text()}`);
+    }
+
+    await page.goto('/backups');
+    await expect(page.getByRole('heading', { name: /cloud backups/i })).toBeVisible();
+    await expect(page.getByText(/no backup destinations/i)).toBeVisible();
+
+    await page.getByRole('button', { name: /add your first destination|add destination/i }).first().click();
+
+    // Provider should default to S3
+    await expect(page.getByLabel(/provider/i)).toBeVisible();
+    await page.getByLabel(/display name/i).fill('E2E MinIO bucket');
+    await page.getByLabel(/^Bucket/i).fill(MINIO_BUCKET);
+    await page.getByLabel(/^Region/i).fill('us-east-1');
+    await page.getByLabel(/endpoint url/i).fill(MINIO_ENDPOINT);
+    await page.getByLabel(/access key id/i).fill('minioadmin');
+    await page.getByLabel(/secret access key/i).fill('minioadmin');
+
+    await page.getByRole('button', { name: /create destination/i }).click();
+
+    // Card visible
+    const card = page.locator('[data-testid="backup-destination"]', { hasText: 'E2E MinIO bucket' });
+    await expect(card).toBeVisible({ timeout: 15000 });
+
+    // Test connection
+    await card.getByTestId('backup-test').click();
+    await expect(page.getByRole('status')).toContainText(/succeeded/i, { timeout: 15000 });
+
+    // Run now
+    await card.getByTestId('backup-run').click();
+    await expect(page.getByRole('status')).toContainText(/completed successfully/i, { timeout: 30000 });
+
+    // View history
+    await card.getByTestId('backup-history').click();
+    const historyDialog = page.getByRole('dialog', { name: /history/i });
+    await expect(historyDialog).toBeVisible();
+    await expect(historyDialog.getByText(/success/i).first()).toBeVisible({ timeout: 10000 });
+    await historyDialog.getByRole('button', { name: /close/i }).click();
+
+    // Delete
+    await card.getByTestId('backup-delete').click();
+    const confirmDialog = page.getByRole('alertdialog');
+    await expect(confirmDialog).toBeVisible();
+    await confirmDialog.getByRole('button', { name: /^delete$/i }).click();
+
+    await expect(page.getByText(/no backup destinations/i)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -1458,6 +1458,143 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/backups/providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List available backup providers
+         * @description Returns the static catalog of cloud backup providers and their configuration/credential field schemas.
+         */
+        get: operations["listBackupProviders"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/backups/destinations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the user's backup destinations */
+        get: operations["listBackupDestinations"];
+        put?: never;
+        /** Create a backup destination */
+        post: operations["createBackupDestination"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/backups/destinations/{destinationId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a backup destination */
+        get: operations["getBackupDestination"];
+        put?: never;
+        post?: never;
+        /**
+         * Delete a backup destination
+         * @description Deletes the destination and its run history. Does NOT delete objects already uploaded to the remote bucket.
+         */
+        delete: operations["deleteBackupDestination"];
+        options?: never;
+        head?: never;
+        /**
+         * Update a backup destination
+         * @description Partial update — only supplied fields are modified. Credentials cannot be rotated via this endpoint; delete and recreate the destination to change credentials.
+         */
+        patch: operations["updateBackupDestination"];
+        trace?: never;
+    };
+    "/backups/destinations/{destinationId}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Test a backup destination's connectivity
+         * @description Re-runs the provider validation (auth + bucket access) without performing a backup.
+         */
+        post: operations["testBackupDestination"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/backups/destinations/{destinationId}/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Trigger an immediate backup run
+         * @description Runs a backup synchronously and returns the resulting BackupRun audit record. Concurrent runs against the same destination are rejected with 409.
+         */
+        post: operations["runBackupNow"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/backups/destinations/{destinationId}/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List backup runs for a destination */
+        get: operations["listBackupRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/backups/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single backup run by ID */
+        get: operations["getBackupRun"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -3403,6 +3540,156 @@ export interface components {
                 totalPages: number;
             };
         };
+        /**
+         * Format: uuid
+         * @description Backup destination UUID
+         */
+        BackupDestinationId: string;
+        /**
+         * @description Cadence at which scheduled runs fire (UTC). 'manual' disables scheduling.
+         * @enum {string}
+         */
+        BackupSchedule: "manual" | "daily" | "weekly" | "monthly";
+        /**
+         * @description Operational status of a destination. 'error' is set automatically after 3 consecutive run failures.
+         * @enum {string}
+         */
+        BackupStatus: "active" | "paused" | "error";
+        /** @enum {string} */
+        BackupRunStatus: "success" | "failed" | "skipped";
+        /** @enum {string} */
+        BackupRunTrigger: "scheduled" | "manual";
+        /**
+         * @description Hint for rendering provider config/credential form fields.
+         * @enum {string}
+         */
+        BackupFieldType: "string" | "password" | "region" | "url";
+        BackupField: {
+            /** @description Stable field key sent back as part of the config or credentials map. */
+            name: string;
+            /** @description Human-readable label. */
+            label: string;
+            type: components["schemas"]["BackupFieldType"];
+            required: boolean;
+            description?: string;
+            placeholder?: string;
+        };
+        BackupFieldSchema: {
+            fields: components["schemas"]["BackupField"][];
+        };
+        BackupProvider: {
+            /** @example s3 */
+            name: string;
+            /** @example Amazon S3 (and compatible) */
+            displayName: string;
+            description?: string;
+            configSchema: components["schemas"]["BackupFieldSchema"];
+            credentialSchema: components["schemas"]["BackupFieldSchema"];
+        };
+        BackupDestination: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            userId: string;
+            /** @example s3 */
+            provider: string;
+            displayName: string;
+            /** @description Provider-specific non-secret configuration (e.g. bucket, region, prefix). */
+            config: {
+                [key: string]: unknown;
+            };
+            /** @description Non-sensitive hint about the stored credential (e.g. last 4 of access key). */
+            credentialHint?: string;
+            schedule: components["schemas"]["BackupSchedule"];
+            scheduleHourUtc?: number;
+            /** @description 0=Sunday, 6=Saturday. Required when schedule=weekly. */
+            scheduleDayOfWeek?: number;
+            /** @description Day of month for monthly schedule. Capped at 28 to avoid month-end edge cases. */
+            scheduleDayOfMonth?: number;
+            /** @description Number of historical backups to retain. 0 means keep all. */
+            retentionCount: number;
+            status: components["schemas"]["BackupStatus"];
+            lastError?: string;
+            enabled: boolean;
+            consecutiveFailures?: number;
+            /** Format: date-time */
+            lastRunAt?: string;
+            /** Format: date-time */
+            lastSuccessAt?: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        BackupDestinationCreate: {
+            /** @example s3 */
+            provider: string;
+            displayName: string;
+            config: {
+                [key: string]: unknown;
+            };
+            /** @description Secret fields. Stored encrypted at rest (AES-256-GCM) and never returned in any response. */
+            credentials: {
+                [key: string]: unknown;
+            };
+            schedule: components["schemas"]["BackupSchedule"];
+            scheduleHourUtc?: number;
+            scheduleDayOfWeek?: number;
+            scheduleDayOfMonth?: number;
+            /** @default 30 */
+            retentionCount: number;
+            /** @default true */
+            enabled: boolean;
+        };
+        /** @description Partial update — only supplied fields are modified. */
+        BackupDestinationUpdate: {
+            displayName?: string;
+            schedule?: components["schemas"]["BackupSchedule"];
+            scheduleHourUtc?: number;
+            scheduleDayOfWeek?: number;
+            scheduleDayOfMonth?: number;
+            retentionCount?: number;
+            enabled?: boolean;
+        };
+        BackupTestResult: {
+            success: boolean;
+            message?: string;
+        };
+        BackupRun: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            destinationId: string;
+            /** Format: uuid */
+            userId: string;
+            status: components["schemas"]["BackupRunStatus"];
+            trigger?: components["schemas"]["BackupRunTrigger"];
+            /** Format: date-time */
+            startedAt: string;
+            /** Format: date-time */
+            completedAt?: string;
+            durationMs?: number;
+            /** Format: int64 */
+            sizeBytes?: number;
+            sha256?: string;
+            flightCount?: number;
+            aircraftCount?: number;
+            licenseCount?: number;
+            credentialCount?: number;
+            remotePath?: string;
+            errorMessage?: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        PaginatedBackupRuns: {
+            data: components["schemas"]["BackupRun"][];
+            pagination: {
+                page: number;
+                pageSize: number;
+                total: number;
+                totalPages: number;
+            };
+        };
         Error: {
             /**
              * @description Error message
@@ -3489,6 +3776,8 @@ export interface components {
     parameters: {
         /** @description License UUID */
         LicenseId: string;
+        /** @description Backup destination UUID */
+        BackupDestinationId: string;
         /** @description Aircraft UUID */
         AircraftId: string;
         /** @description Flight UUID */
@@ -6039,6 +6328,289 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    listBackupProviders: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Provider catalog */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupProvider"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Cloud backups are not configured on this server */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listBackupDestinations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Destination list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupDestination"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Cloud backups are not configured on this server */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    createBackupDestination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BackupDestinationCreate"];
+            };
+        };
+        responses: {
+            /** @description Destination created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupDestination"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            /** @description Cloud backups are not configured on this server */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getBackupDestination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Destination */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupDestination"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteBackupDestination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Destination deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateBackupDestination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["BackupDestinationUpdate"];
+            };
+        };
+        responses: {
+            /** @description Destination updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupDestination"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    testBackupDestination: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Test result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupTestResult"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    runBackupNow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run started (or completed; the body reflects the final state) */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupRun"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            /** @description Another run is already in progress for this destination */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listBackupRuns: {
+        parameters: {
+            query?: {
+                page?: number;
+                pageSize?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Backup destination UUID */
+                destinationId: components["parameters"]["BackupDestinationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated run history */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedBackupRuns"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getBackupRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                runId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Run */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BackupRun"];
+                };
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];

--- a/src/components/backups/BackupDestinationForm.tsx
+++ b/src/components/backups/BackupDestinationForm.tsx
@@ -1,0 +1,348 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { components } from '../../api/schema';
+import {
+  useBackupProviders,
+  useCreateBackupDestination,
+  useUpdateBackupDestination,
+} from '../../hooks/useBackups';
+import { extractApiError } from '../../lib/errors';
+
+type BackupDestination = components['schemas']['BackupDestination'];
+type BackupField = components['schemas']['BackupField'];
+type BackupSchedule = components['schemas']['BackupSchedule'];
+
+interface BackupDestinationFormProps {
+  destination?: BackupDestination | null;
+  onClose: () => void;
+}
+
+const SCHEDULES: BackupSchedule[] = ['manual', 'daily', 'weekly', 'monthly'];
+
+export default function BackupDestinationForm({ destination, onClose }: BackupDestinationFormProps) {
+  const { t } = useTranslation('backups');
+  const { data: providers, isLoading: providersLoading } = useBackupProviders();
+  const createMutation = useCreateBackupDestination();
+  const updateMutation = useUpdateBackupDestination();
+
+  const isEditing = !!destination;
+
+  const [providerName, setProviderName] = useState(destination?.provider ?? '');
+  const [displayName, setDisplayName] = useState(destination?.displayName ?? '');
+  const [schedule, setSchedule] = useState<BackupSchedule>(destination?.schedule ?? 'manual');
+  const [scheduleHourUtc, setScheduleHourUtc] = useState<number>(destination?.scheduleHourUtc ?? 3);
+  const [scheduleDayOfWeek, setScheduleDayOfWeek] = useState<number>(destination?.scheduleDayOfWeek ?? 0);
+  const [scheduleDayOfMonth, setScheduleDayOfMonth] = useState<number>(destination?.scheduleDayOfMonth ?? 1);
+  const [retentionCount, setRetentionCount] = useState<number>(destination?.retentionCount ?? 30);
+  const [enabled, setEnabled] = useState<boolean>(destination?.enabled ?? true);
+  const [config, setConfig] = useState<Record<string, string>>(() => {
+    const out: Record<string, string> = {};
+    if (destination?.config) {
+      for (const [k, v] of Object.entries(destination.config)) {
+        out[k] = v == null ? '' : String(v);
+      }
+    }
+    return out;
+  });
+  const [credentials, setCredentials] = useState<Record<string, string>>({});
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Auto-select first provider when creating
+  useEffect(() => {
+    if (!isEditing && !providerName && providers && providers.length > 0) {
+      setProviderName(providers[0].name);
+    }
+  }, [providers, providerName, isEditing]);
+
+  const selectedProvider = useMemo(
+    () => providers?.find((p) => p.name === providerName) ?? null,
+    [providers, providerName],
+  );
+
+  const handleConfigChange = (name: string, value: string) => {
+    setConfig((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleCredentialChange = (name: string, value: string) => {
+    setCredentials((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setApiError(null);
+    setSubmitting(true);
+    try {
+      if (isEditing && destination) {
+        await updateMutation.mutateAsync({
+          id: destination.id,
+          data: {
+            displayName,
+            schedule,
+            scheduleHourUtc: schedule === 'manual' ? undefined : scheduleHourUtc,
+            scheduleDayOfWeek: schedule === 'weekly' ? scheduleDayOfWeek : undefined,
+            scheduleDayOfMonth: schedule === 'monthly' ? scheduleDayOfMonth : undefined,
+            retentionCount,
+            enabled,
+          },
+        });
+      } else {
+        // Strip empty optional fields from config/credentials
+        const configClean: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(config)) {
+          if (v !== '') configClean[k] = v;
+        }
+        const credsClean: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(credentials)) {
+          if (v !== '') credsClean[k] = v;
+        }
+        await createMutation.mutateAsync({
+          provider: providerName,
+          displayName,
+          config: configClean,
+          credentials: credsClean,
+          schedule,
+          scheduleHourUtc: schedule === 'manual' ? undefined : scheduleHourUtc,
+          scheduleDayOfWeek: schedule === 'weekly' ? scheduleDayOfWeek : undefined,
+          scheduleDayOfMonth: schedule === 'monthly' ? scheduleDayOfMonth : undefined,
+          retentionCount,
+          enabled,
+        });
+      }
+      onClose();
+    } catch (err) {
+      setApiError(extractApiError(err, t('form.failedToSave')));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderField = (
+    field: BackupField,
+    value: string,
+    onChange: (name: string, val: string) => void,
+  ) => {
+    const inputType =
+      field.type === 'password' ? 'password' : field.type === 'url' ? 'url' : 'text';
+    return (
+      <div key={field.name}>
+        <label htmlFor={`bf-${field.name}`} className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          {field.label}
+          {field.required && <span className="text-red-500 ml-0.5">*</span>}
+        </label>
+        <input
+          id={`bf-${field.name}`}
+          type={inputType}
+          required={field.required}
+          placeholder={field.placeholder}
+          value={value}
+          onChange={(e) => onChange(field.name, e.target.value)}
+          autoComplete={field.type === 'password' ? 'new-password' : 'off'}
+          className="input w-full"
+        />
+        {field.description && (
+          <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{field.description}</p>
+        )}
+      </div>
+    );
+  };
+
+  if (providersLoading) {
+    return <div className="text-sm text-slate-500 dark:text-slate-400">{t('form.loadingProviders')}</div>;
+  }
+
+  if (!providers || providers.length === 0) {
+    return (
+      <div className="text-sm text-slate-500 dark:text-slate-400">
+        {t('form.noProviders')}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4" aria-label={isEditing ? t('form.editTitle') : t('form.createTitle')}>
+      {apiError && (
+        <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
+          {apiError}
+        </div>
+      )}
+
+      {!isEditing && (
+        <div>
+          <label htmlFor="bf-provider" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+            {t('form.provider')}
+            <span className="text-red-500 ml-0.5">*</span>
+          </label>
+          <select
+            id="bf-provider"
+            className="input w-full"
+            value={providerName}
+            onChange={(e) => {
+              setProviderName(e.target.value);
+              setConfig({});
+              setCredentials({});
+            }}
+            required
+          >
+            {providers.map((p) => (
+              <option key={p.name} value={p.name}>
+                {p.displayName}
+              </option>
+            ))}
+          </select>
+          {selectedProvider?.description && (
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{selectedProvider.description}</p>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="bf-displayName" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          {t('form.displayName')}
+          <span className="text-red-500 ml-0.5">*</span>
+        </label>
+        <input
+          id="bf-displayName"
+          type="text"
+          required
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder={t('form.displayNamePlaceholder')}
+          className="input w-full"
+        />
+      </div>
+
+      {!isEditing && selectedProvider && (
+        <>
+          {selectedProvider.configSchema.fields.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{t('form.configSection')}</h3>
+              {selectedProvider.configSchema.fields.map((f) =>
+                renderField(f, config[f.name] ?? '', handleConfigChange),
+              )}
+            </div>
+          )}
+          {selectedProvider.credentialSchema.fields.length > 0 && (
+            <div className="space-y-3">
+              <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{t('form.credentialsSection')}</h3>
+              <p className="text-xs text-slate-500 dark:text-slate-400">{t('form.credentialsHint')}</p>
+              {selectedProvider.credentialSchema.fields.map((f) =>
+                renderField(f, credentials[f.name] ?? '', handleCredentialChange),
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      <div className="space-y-3">
+        <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-300">{t('form.scheduleSection')}</h3>
+        <div>
+          <label htmlFor="bf-schedule" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+            {t('form.schedule')}
+          </label>
+          <select
+            id="bf-schedule"
+            className="input w-full"
+            value={schedule}
+            onChange={(e) => setSchedule(e.target.value as BackupSchedule)}
+          >
+            {SCHEDULES.map((s) => (
+              <option key={s} value={s}>
+                {t(`schedule.${s}`)}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {schedule !== 'manual' && (
+          <div>
+            <label htmlFor="bf-hour" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              {t('form.scheduleHour')}
+            </label>
+            <input
+              id="bf-hour"
+              type="number"
+              min={0}
+              max={23}
+              value={scheduleHourUtc}
+              onChange={(e) => setScheduleHourUtc(Number(e.target.value))}
+              className="input w-full"
+            />
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{t('form.scheduleHourHint')}</p>
+          </div>
+        )}
+
+        {schedule === 'weekly' && (
+          <div>
+            <label htmlFor="bf-dow" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              {t('form.scheduleDayOfWeek')}
+            </label>
+            <select
+              id="bf-dow"
+              className="input w-full"
+              value={scheduleDayOfWeek}
+              onChange={(e) => setScheduleDayOfWeek(Number(e.target.value))}
+            >
+              {[0, 1, 2, 3, 4, 5, 6].map((d) => (
+                <option key={d} value={d}>
+                  {t(`days.${d}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        {schedule === 'monthly' && (
+          <div>
+            <label htmlFor="bf-dom" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              {t('form.scheduleDayOfMonth')}
+            </label>
+            <input
+              id="bf-dom"
+              type="number"
+              min={1}
+              max={28}
+              value={scheduleDayOfMonth}
+              onChange={(e) => setScheduleDayOfMonth(Number(e.target.value))}
+              className="input w-full"
+            />
+          </div>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="bf-retention" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+          {t('form.retention')}
+        </label>
+        <input
+          id="bf-retention"
+          type="number"
+          min={0}
+          value={retentionCount}
+          onChange={(e) => setRetentionCount(Number(e.target.value))}
+          className="input w-full"
+        />
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{t('form.retentionHint')}</p>
+      </div>
+
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+          className="rounded"
+        />
+        <span className="text-sm text-slate-700 dark:text-slate-300">{t('form.enabled')}</span>
+      </label>
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-slate-100 dark:border-slate-700">
+        <button type="button" onClick={onClose} className="btn-ghost">
+          {t('form.cancel')}
+        </button>
+        <button type="submit" disabled={submitting} className="btn-primary">
+          {submitting ? t('form.saving') : isEditing ? t('form.save') : t('form.create')}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/backups/BackupDestinationForm.tsx
+++ b/src/components/backups/BackupDestinationForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { components } from '../../api/schema';
 import {
@@ -27,7 +27,10 @@ export default function BackupDestinationForm({ destination, onClose }: BackupDe
 
   const isEditing = !!destination;
 
-  const [providerName, setProviderName] = useState(destination?.provider ?? '');
+  const [providerNameOverride, setProviderName] = useState<string | null>(
+    destination?.provider ?? null,
+  );
+  const providerName = providerNameOverride ?? providers?.[0]?.name ?? '';
   const [displayName, setDisplayName] = useState(destination?.displayName ?? '');
   const [schedule, setSchedule] = useState<BackupSchedule>(destination?.schedule ?? 'manual');
   const [scheduleHourUtc, setScheduleHourUtc] = useState<number>(destination?.scheduleHourUtc ?? 3);
@@ -47,13 +50,6 @@ export default function BackupDestinationForm({ destination, onClose }: BackupDe
   const [credentials, setCredentials] = useState<Record<string, string>>({});
   const [apiError, setApiError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-
-  // Auto-select first provider when creating
-  useEffect(() => {
-    if (!isEditing && !providerName && providers && providers.length > 0) {
-      setProviderName(providers[0].name);
-    }
-  }, [providers, providerName, isEditing]);
 
   const selectedProvider = useMemo(
     () => providers?.find((p) => p.name === providerName) ?? null,

--- a/src/components/backups/BackupRunsList.tsx
+++ b/src/components/backups/BackupRunsList.tsx
@@ -1,0 +1,100 @@
+import { useTranslation } from 'react-i18next';
+import { useBackupRuns } from '../../hooks/useBackups';
+import { useFormatPrefs } from '../../hooks/useFormatPrefs';
+
+interface BackupRunsListProps {
+  destinationId: string;
+}
+
+function formatBytes(bytes?: number): string {
+  if (bytes == null) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  return `${value.toFixed(1)} ${units[unitIndex]}`;
+}
+
+function formatDuration(ms?: number): string {
+  if (ms == null) return '—';
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`;
+  const mins = Math.floor(ms / 60_000);
+  const secs = Math.floor((ms % 60_000) / 1000);
+  return `${mins}m ${secs}s`;
+}
+
+export default function BackupRunsList({ destinationId }: BackupRunsListProps) {
+  const { t } = useTranslation('backups');
+  const { fmtDate } = useFormatPrefs();
+  const { data, isLoading, error } = useBackupRuns(destinationId, { pageSize: 20 });
+
+  if (isLoading) {
+    return <div className="text-sm text-slate-500 dark:text-slate-400 py-4">{t('runs.loading')}</div>;
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-red-600 dark:text-red-400 py-4">{t('runs.loadError')}</div>
+    );
+  }
+
+  if (!data || data.data.length === 0) {
+    return <div className="text-sm text-slate-500 dark:text-slate-400 py-4">{t('runs.empty')}</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="text-xs uppercase text-slate-500 dark:text-slate-400">
+          <tr>
+            <th className="text-left py-2 pr-3">{t('runs.status')}</th>
+            <th className="text-left py-2 pr-3">{t('runs.startedAt')}</th>
+            <th className="text-left py-2 pr-3">{t('runs.trigger')}</th>
+            <th className="text-left py-2 pr-3">{t('runs.duration')}</th>
+            <th className="text-left py-2 pr-3">{t('runs.size')}</th>
+            <th className="text-left py-2 pr-3">{t('runs.remotePath')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.data.map((run) => {
+            const badge =
+              run.status === 'success'
+                ? 'badge-current'
+                : run.status === 'failed'
+                ? 'badge-expired'
+                : 'badge-expiring';
+            return (
+              <tr key={run.id} className="border-t border-slate-100 dark:border-slate-800 align-top">
+                <td className="py-2 pr-3">
+                  <span className={`badge text-xs ${badge}`}>{t(`runs.statuses.${run.status}`)}</span>
+                </td>
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-300">
+                  {fmtDate(run.startedAt)}{' '}
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {new Date(run.startedAt).toLocaleTimeString()}
+                  </span>
+                </td>
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-300">
+                  {run.trigger ? t(`runs.triggers.${run.trigger}`) : '—'}
+                </td>
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-300">{formatDuration(run.durationMs)}</td>
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-300">{formatBytes(run.sizeBytes)}</td>
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-300 break-all">
+                  {run.remotePath || '—'}
+                  {run.errorMessage && (
+                    <div className="text-xs text-red-600 dark:text-red-400 mt-0.5">{run.errorMessage}</div>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Outlet, Link, NavLink, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard, Plane, FileText, PlaneTakeoff, BarChart3, Map,
-  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle, Bug, ExternalLink, Cloud
+  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle, Bug, ExternalLink
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useLogout } from '../../hooks/useAuth';
@@ -101,7 +101,6 @@ export default function Layout() {
           <SidebarItem to="/map" label={t('nav:map')} icon={<Map className="w-5 h-5" />} />
           <SidebarItem to="/import" label={t('nav:import')} icon={<Upload className="w-5 h-5" />} />
           <SidebarItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} />
-          <SidebarItem to="/backups" label={t('nav:backups')} icon={<Cloud className="w-5 h-5" />} />
         </nav>
         <div className="border-t border-slate-200 dark:border-slate-800 p-3 space-y-0.5">
           {user?.isAdmin && (
@@ -175,7 +174,6 @@ export default function Layout() {
               <MoreMenuItem to="/map" label={t('nav:map')} icon={<Map className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/import" label={t('nav:import')} icon={<Upload className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
-              <MoreMenuItem to="/backups" label={t('nav:backups')} icon={<Cloud className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/profile" label={t('nav:profileSettings')} icon={<User className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/help" label={t('nav:help')} icon={<HelpCircle className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuExternalItem

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Outlet, Link, NavLink, useNavigate } from 'react-router-dom';
 import {
   LayoutDashboard, Plane, FileText, PlaneTakeoff, BarChart3, Map,
-  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle, Bug, ExternalLink
+  Award, User, Upload, Download, Shield, LogOut, Menu, Plus, ShieldCheck, HelpCircle, Bug, ExternalLink, Cloud
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useLogout } from '../../hooks/useAuth';
@@ -101,6 +101,7 @@ export default function Layout() {
           <SidebarItem to="/map" label={t('nav:map')} icon={<Map className="w-5 h-5" />} />
           <SidebarItem to="/import" label={t('nav:import')} icon={<Upload className="w-5 h-5" />} />
           <SidebarItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} />
+          <SidebarItem to="/backups" label={t('nav:backups')} icon={<Cloud className="w-5 h-5" />} />
         </nav>
         <div className="border-t border-slate-200 dark:border-slate-800 p-3 space-y-0.5">
           {user?.isAdmin && (
@@ -174,6 +175,7 @@ export default function Layout() {
               <MoreMenuItem to="/map" label={t('nav:map')} icon={<Map className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/import" label={t('nav:import')} icon={<Upload className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/export" label={t('nav:export')} icon={<Download className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
+              <MoreMenuItem to="/backups" label={t('nav:backups')} icon={<Cloud className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/profile" label={t('nav:profileSettings')} icon={<User className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuItem to="/help" label={t('nav:help')} icon={<HelpCircle className="w-5 h-5" />} onClick={() => setShowMoreMenu(false)} />
               <MoreMenuExternalItem

--- a/src/hooks/useBackups.ts
+++ b/src/hooks/useBackups.ts
@@ -1,0 +1,148 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { components } from '../api/schema';
+
+type BackupProvider = components['schemas']['BackupProvider'];
+type BackupDestination = components['schemas']['BackupDestination'];
+type BackupDestinationCreate = components['schemas']['BackupDestinationCreate'];
+type BackupDestinationUpdate = components['schemas']['BackupDestinationUpdate'];
+type BackupTestResult = components['schemas']['BackupTestResult'];
+type BackupRun = components['schemas']['BackupRun'];
+type PaginatedBackupRuns = components['schemas']['PaginatedBackupRuns'];
+
+export const useBackupProviders = (enabled = true) => {
+  return useQuery({
+    queryKey: ['backup-providers'],
+    enabled,
+    queryFn: async (): Promise<BackupProvider[]> => {
+      const { data, error } = await apiClient.GET('/backups/providers');
+      if (error) throw error;
+      return data as BackupProvider[];
+    },
+    staleTime: 1000 * 60 * 60,
+  });
+};
+
+export const useBackupDestinations = () => {
+  return useQuery({
+    queryKey: ['backup-destinations'],
+    queryFn: async (): Promise<BackupDestination[]> => {
+      const { data, error } = await apiClient.GET('/backups/destinations');
+      if (error) throw error;
+      return data as BackupDestination[];
+    },
+  });
+};
+
+export const useBackupDestination = (destinationId: string | null) => {
+  return useQuery({
+    queryKey: ['backup-destinations', destinationId],
+    enabled: !!destinationId,
+    queryFn: async (): Promise<BackupDestination> => {
+      const { data, error } = await apiClient.GET('/backups/destinations/{destinationId}', {
+        params: { path: { destinationId: destinationId! } },
+      });
+      if (error) throw error;
+      return data as BackupDestination;
+    },
+  });
+};
+
+export const useCreateBackupDestination = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: BackupDestinationCreate): Promise<BackupDestination> => {
+      const { data: result, error } = await apiClient.POST('/backups/destinations', {
+        body: data,
+      });
+      if (error) throw error;
+      return result as BackupDestination;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['backup-destinations'] });
+    },
+  });
+};
+
+export const useUpdateBackupDestination = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, data }: { id: string; data: BackupDestinationUpdate }): Promise<BackupDestination> => {
+      const { data: result, error } = await apiClient.PATCH('/backups/destinations/{destinationId}', {
+        params: { path: { destinationId: id } },
+        body: data,
+      });
+      if (error) throw error;
+      return result as BackupDestination;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['backup-destinations'] });
+      queryClient.invalidateQueries({ queryKey: ['backup-destinations', variables.id] });
+    },
+  });
+};
+
+export const useDeleteBackupDestination = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string): Promise<void> => {
+      const { error } = await apiClient.DELETE('/backups/destinations/{destinationId}', {
+        params: { path: { destinationId: id } },
+      });
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['backup-destinations'] });
+    },
+  });
+};
+
+export const useTestBackupDestination = () => {
+  return useMutation({
+    mutationFn: async (id: string): Promise<BackupTestResult> => {
+      const { data, error } = await apiClient.POST('/backups/destinations/{destinationId}/test', {
+        params: { path: { destinationId: id } },
+      });
+      if (error) throw error;
+      return data as BackupTestResult;
+    },
+  });
+};
+
+export const useRunBackupNow = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string): Promise<BackupRun> => {
+      const { data, error } = await apiClient.POST('/backups/destinations/{destinationId}/run', {
+        params: { path: { destinationId: id } },
+      });
+      if (error) throw error;
+      return data as BackupRun;
+    },
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: ['backup-destinations'] });
+      queryClient.invalidateQueries({ queryKey: ['backup-runs', id] });
+    },
+  });
+};
+
+export const useBackupRuns = (
+  destinationId: string | null,
+  options: { page?: number; pageSize?: number } = {},
+) => {
+  const { page = 1, pageSize = 20 } = options;
+  return useQuery({
+    queryKey: ['backup-runs', destinationId, page, pageSize],
+    enabled: !!destinationId,
+    queryFn: async (): Promise<PaginatedBackupRuns> => {
+      const { data, error } = await apiClient.GET('/backups/destinations/{destinationId}/runs', {
+        params: {
+          path: { destinationId: destinationId! },
+          query: { page, pageSize },
+        },
+      });
+      if (error) throw error;
+      return data as PaginatedBackupRuns;
+    },
+  });
+};

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -16,6 +16,7 @@ import enReports from './locales/en/reports.json';
 import enSettings from './locales/en/settings.json';
 import enImport from './locales/en/import.json';
 import enHelp from './locales/en/help.json';
+import enBackups from './locales/en/backups.json';
 
 // German namespaces
 import deCommon from './locales/de/common.json';
@@ -31,6 +32,7 @@ import deReports from './locales/de/reports.json';
 import deSettings from './locales/de/settings.json';
 import deImport from './locales/de/import.json';
 import deHelp from './locales/de/help.json';
+import deBackups from './locales/de/backups.json';
 
 export const supportedLanguages = ['en', 'de'] as const;
 export type SupportedLanguage = (typeof supportedLanguages)[number];
@@ -59,6 +61,7 @@ i18n
         settings: enSettings,
         import: enImport,
         help: enHelp,
+        backups: enBackups,
       },
       de: {
         common: deCommon,
@@ -74,6 +77,7 @@ i18n
         settings: deSettings,
         import: deImport,
         help: deHelp,
+        backups: deBackups,
       },
     },
     fallbackLng: 'en',
@@ -81,7 +85,7 @@ i18n
     ns: [
       'common', 'auth', 'nav', 'flights', 'aircraft', 'dashboard',
       'currency', 'licenses', 'credentials', 'reports', 'settings',
-      'import', 'help',
+      'import', 'help', 'backups',
     ],
     interpolation: {
       escapeValue: false, // React already escapes

--- a/src/i18n/locales/de/backups.json
+++ b/src/i18n/locales/de/backups.json
@@ -1,0 +1,104 @@
+{
+  "title": "Cloud-Backups",
+  "subtitle": "Sende verschlüsselte Sicherungen deiner Flüge, Flugzeuge, Lizenzen und Nachweise nach Plan an einen Cloud-Speicher.",
+  "addDestination": "Ziel hinzufügen",
+  "addFirst": "Erstes Ziel hinzufügen",
+  "empty": "Noch keine Backup-Ziele.",
+  "disabled": "Cloud-Backups sind auf diesem Server nicht aktiviert. Bitte deinen Administrator, BACKUP_CREDENTIALS_KEY zu setzen.",
+  "paused": "pausiert",
+  "test": "Testen",
+  "testing": "Teste…",
+  "runNow": "Jetzt sichern",
+  "running": "Sichere…",
+  "edit": "Bearbeiten",
+  "delete": "Löschen",
+  "deleteTitle": "Backup-Ziel löschen",
+  "deleteConfirm": "„{{name}}\" und den Verlauf endgültig löschen?",
+  "lastRun": "Letzter Lauf",
+  "lastSuccess": "Letzter Erfolg",
+  "credentialHint": "Zugang",
+  "retention": "Aufbewahrung",
+  "retentionAll": "Alle behalten",
+  "status": {
+    "active": "Aktiv",
+    "paused": "Pausiert",
+    "error": "Fehler"
+  },
+  "schedule": {
+    "manual": "Nur manuell",
+    "daily": "Täglich",
+    "weekly": "Wöchentlich",
+    "monthly": "Monatlich"
+  },
+  "days": {
+    "0": "Sonntag",
+    "1": "Montag",
+    "2": "Dienstag",
+    "3": "Mittwoch",
+    "4": "Donnerstag",
+    "5": "Freitag",
+    "6": "Samstag"
+  },
+  "error": {
+    "title": "Backup-Ziele konnten nicht geladen werden",
+    "message": "Beim Laden deiner Backup-Ziele ist ein Fehler aufgetreten. Bitte erneut versuchen."
+  },
+  "messages": {
+    "testSuccess": "Verbindung zu „{{name}}\" erfolgreich.",
+    "testFailed": "Verbindungstest fehlgeschlagen.",
+    "runSuccess": "Backup von „{{name}}\" erfolgreich abgeschlossen.",
+    "runFailed": "Backup-Lauf fehlgeschlagen.",
+    "deleteFailed": "Ziel konnte nicht gelöscht werden."
+  },
+  "form": {
+    "createTitle": "Backup-Ziel hinzufügen",
+    "editTitle": "Backup-Ziel bearbeiten",
+    "provider": "Anbieter",
+    "displayName": "Anzeigename",
+    "displayNamePlaceholder": "z. B. Mein S3-Bucket",
+    "configSection": "Ziel",
+    "credentialsSection": "Zugangsdaten",
+    "credentialsHint": "Verschlüsselt gespeichert. Zugangsdaten werden niemals zurückgegeben.",
+    "scheduleSection": "Zeitplan",
+    "schedule": "Häufigkeit",
+    "scheduleHour": "Stunde (UTC)",
+    "scheduleHourHint": "0–23. Die Minute ist nicht konfigurierbar.",
+    "scheduleDayOfWeek": "Wochentag",
+    "scheduleDayOfMonth": "Tag des Monats",
+    "retention": "Letzte N Backups behalten",
+    "retentionHint": "0 = alle behalten. Ältere Backups werden nach jedem erfolgreichen Lauf entfernt.",
+    "enabled": "Aktiviert",
+    "cancel": "Abbrechen",
+    "save": "Änderungen speichern",
+    "create": "Ziel erstellen",
+    "saving": "Speichere…",
+    "close": "Schließen",
+    "loadingProviders": "Lade Anbieter…",
+    "noProviders": "Auf diesem Server sind keine Backup-Anbieter verfügbar.",
+    "failedToSave": "Ziel konnte nicht gespeichert werden."
+  },
+  "history": {
+    "title": "Verlauf — {{name}}",
+    "button": "Verlauf"
+  },
+  "runs": {
+    "status": "Status",
+    "startedAt": "Gestartet",
+    "trigger": "Auslöser",
+    "duration": "Dauer",
+    "size": "Größe",
+    "remotePath": "Remote-Pfad",
+    "loading": "Lade Verlauf…",
+    "loadError": "Verlauf konnte nicht geladen werden.",
+    "empty": "Noch keine Backup-Läufe.",
+    "statuses": {
+      "success": "Erfolg",
+      "failed": "Fehlgeschlagen",
+      "skipped": "Übersprungen"
+    },
+    "triggers": {
+      "scheduled": "Geplant",
+      "manual": "Manuell"
+    }
+  }
+}

--- a/src/i18n/locales/de/nav.json
+++ b/src/i18n/locales/de/nav.json
@@ -9,6 +9,7 @@
   "map": "Karte",
   "import": "Import",
   "export": "Export",
+  "backups": "Cloud-Backups",
   "admin": "Admin",
   "help": "Hilfe",
   "reportBug": "Fehler melden",

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -4,6 +4,7 @@
     "preferences": "Einstellungen",
     "account": "Konto",
     "notifications": "Benachrichtigungen",
+    "backups": "Cloud-Backups",
     "data": "Daten & Sicherheit"
   },
   "timeDisplay": {

--- a/src/i18n/locales/en/backups.json
+++ b/src/i18n/locales/en/backups.json
@@ -1,0 +1,104 @@
+{
+  "title": "Cloud Backups",
+  "subtitle": "Send encrypted backups of your flights, aircraft, licenses and credentials to a cloud destination on a schedule.",
+  "addDestination": "Add destination",
+  "addFirst": "Add your first destination",
+  "empty": "No backup destinations yet.",
+  "disabled": "Cloud backups are not enabled on this server. Ask your administrator to set BACKUP_CREDENTIALS_KEY.",
+  "paused": "paused",
+  "test": "Test",
+  "testing": "Testing…",
+  "runNow": "Run now",
+  "running": "Running…",
+  "edit": "Edit",
+  "delete": "Delete",
+  "deleteTitle": "Delete backup destination",
+  "deleteConfirm": "Delete \"{{name}}\" and its run history? This cannot be undone.",
+  "lastRun": "Last run",
+  "lastSuccess": "Last success",
+  "credentialHint": "Credential",
+  "retention": "Retention",
+  "retentionAll": "Keep all",
+  "status": {
+    "active": "Active",
+    "paused": "Paused",
+    "error": "Error"
+  },
+  "schedule": {
+    "manual": "Manual only",
+    "daily": "Daily",
+    "weekly": "Weekly",
+    "monthly": "Monthly"
+  },
+  "days": {
+    "0": "Sunday",
+    "1": "Monday",
+    "2": "Tuesday",
+    "3": "Wednesday",
+    "4": "Thursday",
+    "5": "Friday",
+    "6": "Saturday"
+  },
+  "error": {
+    "title": "Failed to load backup destinations",
+    "message": "An error occurred while loading your backup destinations. Please try again."
+  },
+  "messages": {
+    "testSuccess": "Connection to \"{{name}}\" succeeded.",
+    "testFailed": "Connection test failed.",
+    "runSuccess": "Backup of \"{{name}}\" completed successfully.",
+    "runFailed": "Backup run failed.",
+    "deleteFailed": "Failed to delete destination."
+  },
+  "form": {
+    "createTitle": "Add backup destination",
+    "editTitle": "Edit backup destination",
+    "provider": "Provider",
+    "displayName": "Display name",
+    "displayNamePlaceholder": "e.g. My S3 bucket",
+    "configSection": "Destination",
+    "credentialsSection": "Credentials",
+    "credentialsHint": "Stored encrypted at rest. Credentials are never returned by the API.",
+    "scheduleSection": "Schedule",
+    "schedule": "Cadence",
+    "scheduleHour": "Hour (UTC)",
+    "scheduleHourHint": "0–23. The minute is not configurable.",
+    "scheduleDayOfWeek": "Day of week",
+    "scheduleDayOfMonth": "Day of month",
+    "retention": "Keep last N backups",
+    "retentionHint": "0 keeps all backups. Older backups are deleted from the destination after each successful run.",
+    "enabled": "Enabled",
+    "cancel": "Cancel",
+    "save": "Save changes",
+    "create": "Create destination",
+    "saving": "Saving…",
+    "close": "Close",
+    "loadingProviders": "Loading providers…",
+    "noProviders": "No backup providers are available on this server.",
+    "failedToSave": "Failed to save destination."
+  },
+  "history": {
+    "title": "History — {{name}}",
+    "button": "History"
+  },
+  "runs": {
+    "status": "Status",
+    "startedAt": "Started",
+    "trigger": "Trigger",
+    "duration": "Duration",
+    "size": "Size",
+    "remotePath": "Remote path",
+    "loading": "Loading runs…",
+    "loadError": "Failed to load run history.",
+    "empty": "No backup runs yet.",
+    "statuses": {
+      "success": "Success",
+      "failed": "Failed",
+      "skipped": "Skipped"
+    },
+    "triggers": {
+      "scheduled": "Scheduled",
+      "manual": "Manual"
+    }
+  }
+}

--- a/src/i18n/locales/en/nav.json
+++ b/src/i18n/locales/en/nav.json
@@ -9,6 +9,7 @@
   "map": "Map",
   "import": "Import",
   "export": "Export",
+  "backups": "Cloud Backups",
   "admin": "Admin",
   "help": "Help",
   "reportBug": "Report a Bug",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -4,6 +4,7 @@
     "preferences": "Preferences",
     "account": "Account",
     "notifications": "Notifications",
+    "backups": "Cloud Backups",
     "data": "Data & Security"
   },
   "timeDisplay": {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -12,6 +12,7 @@ import { extractApiError, extractApiStatus } from '../lib/errors';
 import { NotificationHistory } from '../components/NotificationHistory';
 import { LanguageSwitcher } from '../components/LanguageSwitcher';
 import { PasskeySection } from '../components/auth/PasskeySection';
+import BackupsPage from './backups/BackupsPage';
 
 export default function ProfilePage() {
   const { t } = useTranslation('settings');
@@ -62,7 +63,7 @@ export default function ProfilePage() {
   const [recalcMessage, setRecalcMessage] = useState('');
 
   // Tab state
-  const [activeTab, setActiveTab] = useState<'preferences' | 'account' | 'notifications' | 'data'>('preferences');
+  const [activeTab, setActiveTab] = useState<'preferences' | 'account' | 'notifications' | 'backups' | 'data'>('preferences');
 
   const handleUpdateProfile = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -155,6 +156,7 @@ export default function ProfilePage() {
     { id: 'preferences' as const, label: t('tabs.preferences') },
     { id: 'account' as const, label: t('tabs.account') },
     { id: 'notifications' as const, label: t('tabs.notifications') },
+    { id: 'backups' as const, label: t('tabs.backups') },
     { id: 'data' as const, label: t('tabs.data') },
   ];
 
@@ -473,6 +475,15 @@ export default function ProfilePage() {
           )}
 
           <NotificationHistory />
+        </div>
+      )}
+
+      {/* ════════════════════════════════════════════════════════════════ */}
+      {/* Cloud Backups Tab                                              */}
+      {/* ════════════════════════════════════════════════════════════════ */}
+      {activeTab === 'backups' && (
+        <div className="space-y-6">
+          <BackupsPage />
         </div>
       )}
 

--- a/src/pages/backups/BackupsPage.tsx
+++ b/src/pages/backups/BackupsPage.tsx
@@ -1,0 +1,328 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useBackupDestinations,
+  useDeleteBackupDestination,
+  useRunBackupNow,
+  useTestBackupDestination,
+} from '../../hooks/useBackups';
+import BackupDestinationForm from '../../components/backups/BackupDestinationForm';
+import BackupRunsList from '../../components/backups/BackupRunsList';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { SkeletonGrid } from '../../components/ui/Skeleton';
+import { ErrorState } from '../../components/ui/ErrorState';
+import { useFormatPrefs } from '../../hooks/useFormatPrefs';
+import { extractApiError } from '../../lib/errors';
+import type { components } from '../../api/schema';
+
+type BackupDestination = components['schemas']['BackupDestination'];
+
+export default function BackupsPage() {
+  const { t } = useTranslation('backups');
+  const { fmtDate } = useFormatPrefs();
+  const { data: destinations, isLoading, error } = useBackupDestinations();
+  const deleteMutation = useDeleteBackupDestination();
+  const testMutation = useTestBackupDestination();
+  const runMutation = useRunBackupNow();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<BackupDestination | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<BackupDestination | null>(null);
+  const [historyTarget, setHistoryTarget] = useState<BackupDestination | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [statusMessage, setStatusMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  useEffect(() => {
+    if (!statusMessage) return;
+    const t = setTimeout(() => setStatusMessage(null), 6000);
+    return () => clearTimeout(t);
+  }, [statusMessage]);
+
+  const handleTest = async (dest: BackupDestination) => {
+    setBusyId(dest.id);
+    setStatusMessage(null);
+    try {
+      const result = await testMutation.mutateAsync(dest.id);
+      if (result.success) {
+        setStatusMessage({ kind: 'ok', text: t('messages.testSuccess', { name: dest.displayName }) });
+      } else {
+        setStatusMessage({ kind: 'err', text: result.message || t('messages.testFailed') });
+      }
+    } catch (err) {
+      setStatusMessage({ kind: 'err', text: extractApiError(err, t('messages.testFailed')) });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleRun = async (dest: BackupDestination) => {
+    setBusyId(dest.id);
+    setStatusMessage(null);
+    try {
+      const run = await runMutation.mutateAsync(dest.id);
+      if (run.status === 'success') {
+        setStatusMessage({ kind: 'ok', text: t('messages.runSuccess', { name: dest.displayName }) });
+      } else {
+        setStatusMessage({ kind: 'err', text: run.errorMessage || t('messages.runFailed') });
+      }
+    } catch (err) {
+      setStatusMessage({ kind: 'err', text: extractApiError(err, t('messages.runFailed')) });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteMutation.mutateAsync(deleteTarget.id);
+      setDeleteTarget(null);
+    } catch (err) {
+      setStatusMessage({ kind: 'err', text: extractApiError(err, t('messages.deleteFailed')) });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-[1100px] py-6">
+        <SkeletonGrid count={3} />
+      </div>
+    );
+  }
+
+  if (error) {
+    // 503 means feature is disabled (no BACKUP_CREDENTIALS_KEY on server)
+    const status = (error as { response?: { status?: number } } | undefined)?.response?.status;
+    if (status === 503) {
+      return (
+        <div className="mx-auto max-w-[960px] py-6">
+          <div className="card">
+            <h1 className="page-title mb-2">{t('title')}</h1>
+            <p className="text-sm text-slate-500 dark:text-slate-400">{t('disabled')}</p>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className="mx-auto max-w-[960px] py-6">
+        <ErrorState title={t('error.title')} message={t('error.message')} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-[1100px] py-6">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="page-title">{t('title')}</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{t('subtitle')}</p>
+        </div>
+        <button
+          onClick={() => {
+            setEditing(null);
+            setShowForm(true);
+          }}
+          className="btn-primary"
+        >
+          {t('addDestination')}
+        </button>
+      </div>
+
+      {statusMessage && (
+        <div
+          role="status"
+          className={`mb-4 p-3 rounded-lg text-sm border ${
+            statusMessage.kind === 'ok'
+              ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800 text-green-700 dark:text-green-300'
+              : 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800 text-red-700 dark:text-red-300'
+          }`}
+        >
+          {statusMessage.text}
+        </div>
+      )}
+
+      {showForm && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-[1020]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="backup-form-title"
+        >
+          <div className="bg-white dark:bg-slate-800 rounded-xl max-w-xl w-full max-h-[90vh] overflow-y-auto shadow-2xl">
+            <div className="p-6">
+              <div className="flex justify-between items-center mb-6">
+                <h2 id="backup-form-title" className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+                  {editing ? t('form.editTitle') : t('form.createTitle')}
+                </h2>
+                <button
+                  onClick={() => setShowForm(false)}
+                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                  aria-label={t('form.close')}
+                >
+                  ✕
+                </button>
+              </div>
+              <BackupDestinationForm destination={editing} onClose={() => setShowForm(false)} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+        title={t('deleteTitle')}
+        description={t('deleteConfirm', { name: deleteTarget?.displayName ?? '' })}
+        confirmLabel={t('delete')}
+        variant="danger"
+        isLoading={deleteMutation.isPending}
+      />
+
+      {historyTarget && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-[1020]"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="backup-history-title"
+        >
+          <div className="bg-white dark:bg-slate-800 rounded-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto shadow-2xl">
+            <div className="p-6">
+              <div className="flex justify-between items-center mb-4">
+                <h2 id="backup-history-title" className="text-xl font-semibold text-slate-800 dark:text-slate-100">
+                  {t('history.title', { name: historyTarget.displayName })}
+                </h2>
+                <button
+                  onClick={() => setHistoryTarget(null)}
+                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
+                  aria-label={t('form.close')}
+                >
+                  ✕
+                </button>
+              </div>
+              <BackupRunsList destinationId={historyTarget.id} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!destinations || destinations.length === 0 ? (
+        <div className="card text-center py-12">
+          <p className="text-slate-500 dark:text-slate-400 mb-4">{t('empty')}</p>
+          <button
+            onClick={() => {
+              setEditing(null);
+              setShowForm(true);
+            }}
+            className="btn-primary"
+          >
+            {t('addFirst')}
+          </button>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {destinations.map((dest) => {
+            const statusClass =
+              dest.status === 'active'
+                ? 'badge-current'
+                : dest.status === 'error'
+                ? 'badge-expired'
+                : 'badge-expiring';
+            const isBusy = busyId === dest.id;
+            return (
+              <div key={dest.id} className="card" data-testid="backup-destination">
+                <div className="flex items-start justify-between gap-3 mb-2">
+                  <div className="min-w-0">
+                    <h3 className="font-semibold text-slate-800 dark:text-slate-100 truncate">
+                      {dest.displayName}
+                    </h3>
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+                      {dest.provider} · {t(`schedule.${dest.schedule}`)}
+                      {!dest.enabled && <> · {t('paused')}</>}
+                    </p>
+                  </div>
+                  <span className={`badge text-xs shrink-0 ${statusClass}`}>
+                    {t(`status.${dest.status}`)}
+                  </span>
+                </div>
+
+                <dl className="text-sm grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1.5 mb-4">
+                  {dest.lastRunAt && (
+                    <div className="flex justify-between sm:block">
+                      <dt className="text-slate-500 dark:text-slate-400 sm:text-xs sm:uppercase">{t('lastRun')}</dt>
+                      <dd className="text-slate-700 dark:text-slate-300">{fmtDate(dest.lastRunAt)}</dd>
+                    </div>
+                  )}
+                  {dest.lastSuccessAt && (
+                    <div className="flex justify-between sm:block">
+                      <dt className="text-slate-500 dark:text-slate-400 sm:text-xs sm:uppercase">{t('lastSuccess')}</dt>
+                      <dd className="text-slate-700 dark:text-slate-300">{fmtDate(dest.lastSuccessAt)}</dd>
+                    </div>
+                  )}
+                  {dest.credentialHint && (
+                    <div className="flex justify-between sm:block">
+                      <dt className="text-slate-500 dark:text-slate-400 sm:text-xs sm:uppercase">{t('credentialHint')}</dt>
+                      <dd className="text-slate-700 dark:text-slate-300">{dest.credentialHint}</dd>
+                    </div>
+                  )}
+                  <div className="flex justify-between sm:block">
+                    <dt className="text-slate-500 dark:text-slate-400 sm:text-xs sm:uppercase">{t('retention')}</dt>
+                    <dd className="text-slate-700 dark:text-slate-300">
+                      {dest.retentionCount === 0 ? t('retentionAll') : dest.retentionCount}
+                    </dd>
+                  </div>
+                </dl>
+
+                {dest.lastError && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mb-3 break-all">{dest.lastError}</p>
+                )}
+
+                <div className="flex flex-wrap gap-2 pt-2 border-t border-slate-100 dark:border-slate-700">
+                  <button
+                    onClick={() => handleTest(dest)}
+                    disabled={isBusy}
+                    className="btn-ghost btn-sm"
+                    data-testid="backup-test"
+                  >
+                    {isBusy && testMutation.isPending ? t('testing') : t('test')}
+                  </button>
+                  <button
+                    onClick={() => handleRun(dest)}
+                    disabled={isBusy}
+                    className="btn-ghost btn-sm"
+                    data-testid="backup-run"
+                  >
+                    {isBusy && runMutation.isPending ? t('running') : t('runNow')}
+                  </button>
+                  <button
+                    onClick={() => setHistoryTarget(dest)}
+                    className="btn-ghost btn-sm"
+                    data-testid="backup-history"
+                  >
+                    {t('history.button')}
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditing(dest);
+                      setShowForm(true);
+                    }}
+                    className="btn-ghost btn-sm"
+                  >
+                    {t('edit')}
+                  </button>
+                  <button
+                    onClick={() => setDeleteTarget(dest)}
+                    className="btn-ghost btn-sm text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    data-testid="backup-delete"
+                  >
+                    {t('delete')}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/backups/BackupsPage.tsx
+++ b/src/pages/backups/BackupsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useBackupDestinations,
@@ -37,6 +37,15 @@ export default function BackupsPage() {
     const t = setTimeout(() => setStatusMessage(null), 6000);
     return () => clearTimeout(t);
   }, [statusMessage]);
+
+  // Sort destinations: enabled first, then alphabetically by displayName.
+  const sortedDestinations = useMemo(() => {
+    if (!destinations) return destinations;
+    return [...destinations].sort((a, b) => {
+      if (a.enabled !== b.enabled) return a.enabled ? -1 : 1;
+      return a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' });
+    });
+  }, [destinations]);
 
   const handleTest = async (dest: BackupDestination) => {
     setBusyId(dest.id);
@@ -84,7 +93,7 @@ export default function BackupsPage() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-[1100px] py-6">
+      <div className="py-2">
         <SkeletonGrid count={3} />
       </div>
     );
@@ -95,28 +104,19 @@ export default function BackupsPage() {
     const status = (error as { response?: { status?: number } } | undefined)?.response?.status;
     if (status === 503) {
       return (
-        <div className="mx-auto max-w-[960px] py-6">
-          <div className="card">
-            <h1 className="page-title mb-2">{t('title')}</h1>
-            <p className="text-sm text-slate-500 dark:text-slate-400">{t('disabled')}</p>
-          </div>
+        <div className="card">
+          <h2 className="section-title mb-2">{t('title')}</h2>
+          <p className="text-sm text-slate-500 dark:text-slate-400">{t('disabled')}</p>
         </div>
       );
     }
-    return (
-      <div className="mx-auto max-w-[960px] py-6">
-        <ErrorState title={t('error.title')} message={t('error.message')} />
-      </div>
-    );
+    return <ErrorState title={t('error.title')} message={t('error.message')} />;
   }
 
   return (
-    <div className="mx-auto max-w-[1100px] py-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="page-title">{t('title')}</h1>
-          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">{t('subtitle')}</p>
-        </div>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-slate-500 dark:text-slate-400">{t('subtitle')}</p>
         <button
           onClick={() => {
             setEditing(null);
@@ -206,7 +206,7 @@ export default function BackupsPage() {
         </div>
       )}
 
-      {!destinations || destinations.length === 0 ? (
+      {!sortedDestinations || sortedDestinations.length === 0 ? (
         <div className="card text-center py-12">
           <p className="text-slate-500 dark:text-slate-400 mb-4">{t('empty')}</p>
           <button
@@ -221,7 +221,7 @@ export default function BackupsPage() {
         </div>
       ) : (
         <div className="grid gap-4">
-          {destinations.map((dest) => {
+          {sortedDestinations.map((dest) => {
             const statusClass =
               dest.status === 'active'
                 ? 'badge-current'


### PR DESCRIPTION
- Add /backups page with schema-driven destination form, test/run actions, history modal, edit, and delete.
- New useBackups hook covering all backup endpoints generated from the OpenAPI spec.
- Schema-driven form means new providers added on the API need zero frontend changes.
- i18n: new 'backups' namespace in en + de; nav entry under Cloud Backups.
- Sidebar + mobile More menu entries.
- E2E: docker-compose.test.yml gains MinIO + bucket init and the API gets BACKUP_CREDENTIALS_KEY so the new backups.spec.ts can exercise the full create -> test -> run -> history -> delete flow against a real S3 API.
- Unit tests cover the dynamic form render, payload shape, and weekly cadence conditional fields.

All unit tests (266) and E2E tests (82, 3 pre-existing skips) pass.