### PR TITLE
refactor(frontend): full-width list views for aircraft, licenses, credentials

### DIFF
--- a/src/components/licenses/LicenseCard.tsx
+++ b/src/components/licenses/LicenseCard.tsx
@@ -20,14 +20,25 @@ function ExpiryBadge({ expiryDate }: { expiryDate?: string | null }) {
   const expiry = new Date(expiryDate);
   const expired = isPast(expiry);
   const daysLeft = differenceInDays(expiry, new Date());
+  const formatted = fmtDate(expiryDate);
 
   if (expired) {
-    return <span className="text-xs font-medium text-red-600 dark:text-red-400">{t('card.expired')}</span>;
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs">
+        <span className="font-medium text-red-600 dark:text-red-400">{formatted}</span>
+        <span className="badge-expired text-[10px]">{t('card.expired')}</span>
+      </span>
+    );
   }
   if (daysLeft <= 30) {
-    return <span className="text-xs font-medium text-amber-600 dark:text-amber-400">{t('card.expiresInDays', { days: daysLeft })}</span>;
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs">
+        <span className="font-medium text-amber-600 dark:text-amber-400">{formatted}</span>
+        <span className="badge-expiring text-[10px]">{t('card.expiresInDays', { days: daysLeft })}</span>
+      </span>
+    );
   }
-  return <span className="text-xs text-green-600 dark:text-green-400">{fmtDate(expiryDate)}</span>;
+  return <span className="text-xs font-medium text-green-600 dark:text-green-400">{formatted}</span>;
 }
 
 interface LicenseCardProps {
@@ -106,177 +117,218 @@ export default function LicenseCard({ license, onEdit, onDelete }: LicenseCardPr
 
   return (
     <div className="card transition-shadow hover:shadow-md">
-      <div className="flex justify-between items-start mb-3">
-        <div className="flex items-center gap-3">
-          <span className="badge-info font-semibold">{license.licenseType}</span>
-          <div>
-            <h3 className="text-base font-semibold text-slate-800 dark:text-slate-100">
+      <div className="flex flex-col lg:flex-row lg:items-start gap-4 lg:gap-6">
+        {/* Identity */}
+        <div className="lg:w-72 lg:shrink-0">
+          <div className="flex items-center gap-3 flex-wrap">
+            <span className="badge-info font-semibold">{license.licenseType}</span>
+            <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
               {license.regulatoryAuthority} {license.licenseType}
             </h3>
-            <p className="data-sm text-slate-500 dark:text-slate-400">{license.licenseNumber}</p>
           </div>
+          <p className="data-sm text-slate-500 dark:text-slate-400 mt-1 font-mono text-xs">
+            {license.licenseNumber}
+          </p>
+          {license.requiresSeparateLogbook && (
+            <div className="mt-2">
+              <span className="badge-info text-[10px]">YES</span>
+              <span className="ml-1.5 text-xs text-slate-500 dark:text-slate-400">
+                {t('card.separateLogbook')}
+              </span>
+            </div>
+          )}
         </div>
-      </div>
 
-      <div className="space-y-2 text-sm">
-        <div className="flex justify-between">
-          <span className="text-slate-500 dark:text-slate-400">{t('card.regulatoryAuthority')}</span>
-          <span className="font-medium text-slate-700 dark:text-slate-300">{license.regulatoryAuthority}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-slate-500 dark:text-slate-400">{t('card.issuingAuthority')}</span>
-          <span className="font-medium text-slate-700 dark:text-slate-300">{license.issuingAuthority}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-slate-500 dark:text-slate-400">{t('card.issued')}</span>
-          <span className="text-slate-700 dark:text-slate-300">{fmtDate(license.issueDate)}</span>
-        </div>
-        {license.requiresSeparateLogbook && (
-          <div className="flex justify-between">
-            <span className="text-slate-500 dark:text-slate-400">{t('card.separateLogbook')}</span>
-            <span className="badge-info text-[10px]">YES</span>
-          </div>
-        )}
-      </div>
+        {/* Details + Class Ratings */}
+        <div className="flex-1 min-w-0 space-y-4">
+          <dl className="grid grid-cols-1 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm">
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {t('card.regulatoryAuthority')}
+              </dt>
+              <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                {license.regulatoryAuthority}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {t('card.issuingAuthority')}
+              </dt>
+              <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200 break-words">
+                {license.issuingAuthority}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                {t('card.issued')}
+              </dt>
+              <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                {fmtDate(license.issueDate)}
+              </dd>
+            </div>
+          </dl>
 
-      {/* Class Ratings */}
-      <div className="mt-4 pt-3 border-t border-slate-200 dark:border-slate-700">
-        {ratingError && (
-          <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400 px-3 py-2 rounded-lg text-xs mb-2">
-            {ratingError}
-          </div>
-        )}
-        <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
-          {t('classRatings')}
-        </h4>
-        {ratingsLoading ? (
-          <p className="text-xs text-slate-400 dark:text-slate-500">{t('common:loading')}</p>
-        ) : classRatings && classRatings.length > 0 ? (
-          <div className="space-y-1.5">
-            {classRatings.map((rating) => (
-              <div key={rating.id}>
-                {editingRatingId === rating.id ? (
-                  <div className="space-y-2 rounded-md border border-blue-200 dark:border-blue-700 p-2 bg-blue-50/50 dark:bg-blue-900/20">
-                    <div className="text-xs font-medium text-slate-600 dark:text-slate-300">
-                      {t(`classTypeLabels.${rating.classType}`, { defaultValue: rating.classType })}
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div>
-                        <label className="text-xs text-slate-500 dark:text-slate-400">{t('fields.issueDate')}</label>
-                        <input type="date" value={newIssueDate} onChange={(e) => setNewIssueDate(e.target.value)} className="input input-sm mt-0.5" />
-                      </div>
-                      <div>
-                        <label className="text-xs text-slate-500 dark:text-slate-400">{t('classRatingFields.expiryDate')}</label>
-                        <input type="date" value={newExpiryDate} onChange={(e) => setNewExpiryDate(e.target.value)} className="input input-sm mt-0.5" />
-                      </div>
-                    </div>
-                    <div className="flex gap-2">
-                      <button onClick={handleUpdateRating} disabled={!newIssueDate || updateRating.isPending} className="btn-primary btn-sm flex-1 text-xs">
-                        {updateRating.isPending ? t('common:saving') : t('common:save')}
-                      </button>
-                      <button onClick={() => setEditingRatingId(null)} className="btn-secondary btn-sm flex-1 text-xs">{t('common:cancel')}</button>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="font-medium text-slate-700 dark:text-slate-300">
-                      {t(`classTypeLabels.${rating.classType}`, { defaultValue: rating.classType })}
-                    </span>
-                    <div className="flex items-center gap-2">
-                      <ExpiryBadge expiryDate={rating.expiryDate} />
-                      <button
-                        onClick={() => startEditRating(rating)}
-                        className="min-w-[44px] min-h-[44px] flex items-center justify-center text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors text-xs"
-                        title={t('card.editRating')}
-                      >
-                        ✏
-                      </button>
-                      <button
-                        onClick={() => handleDeleteRating(rating.id)}
-                        className="min-w-[44px] min-h-[44px] flex items-center justify-center text-slate-400 hover:text-red-500 dark:hover:text-red-400 transition-colors text-xs font-bold leading-none"
-                        title={t('card.removeRating')}
-                      >
-                        ✕
-                      </button>
-                    </div>
-                  </div>
-                )}
+          {/* Class Ratings */}
+          <div className="pt-3 border-t border-slate-200 dark:border-slate-700">
+            {ratingError && (
+              <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400 px-3 py-2 rounded-lg text-xs mb-2">
+                {ratingError}
               </div>
-            ))}
-          </div>
-        ) : (
-          <p className="text-xs text-slate-400 dark:text-slate-500 italic">{t('card.noClassRatings')}</p>
-        )}
+            )}
+            <div className="flex items-center justify-between mb-2">
+              <h4 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                {t('classRatings')}
+              </h4>
+              {!showAddForm && (
+                <button
+                  onClick={() => setShowAddForm(true)}
+                  className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  {t('card.addRating')}
+                </button>
+              )}
+            </div>
 
-        {/* Add Rating */}
-        {showAddForm ? (
-          <div className="mt-3 space-y-2 rounded-md border border-slate-200 dark:border-slate-600 p-3 bg-slate-50 dark:bg-slate-800/50">
-            <div>
-              <label className="text-xs text-slate-500 dark:text-slate-400">{t('card.classType')}</label>
-              <select
-                value={newClassType}
-                onChange={(e) => setNewClassType(e.target.value)}
-                className="input input-sm mt-0.5"
-              >
-                {CLASS_TYPE_OPTIONS.map((ct) => (
-                  <option key={ct} value={ct}>{t(`classTypeLabels.${ct}`, { defaultValue: ct })}</option>
+            {ratingsLoading ? (
+              <p className="text-xs text-slate-400 dark:text-slate-500">{t('common:loading')}</p>
+            ) : classRatings && classRatings.length > 0 ? (
+              <ul className="divide-y divide-slate-200 dark:divide-slate-700 rounded-md border border-slate-200 dark:border-slate-700 overflow-hidden">
+                {/* Header row (desktop only) */}
+                <li className="hidden sm:grid grid-cols-[1.2fr_1fr_1.4fr_5rem] gap-3 px-3 py-2 bg-slate-50 dark:bg-slate-800/50 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                  <span>{t('classRatingFields.classType')}</span>
+                  <span>{t('card.issued')}</span>
+                  <span>{t('classRatingFields.expiryDate')}</span>
+                  <span className="sr-only">{t('common:actions', { defaultValue: 'Actions' })}</span>
+                </li>
+                {classRatings.map((rating) => (
+                  <li key={rating.id}>
+                    {editingRatingId === rating.id ? (
+                      <div className="space-y-2 p-3 bg-blue-50/50 dark:bg-blue-900/20">
+                        <div className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                          {t(`classTypeLabels.${rating.classType}`, { defaultValue: rating.classType })}
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                          <div>
+                            <label className="text-xs text-slate-500 dark:text-slate-400">{t('fields.issueDate')}</label>
+                            <input type="date" value={newIssueDate} onChange={(e) => setNewIssueDate(e.target.value)} className="input input-sm mt-0.5" />
+                          </div>
+                          <div>
+                            <label className="text-xs text-slate-500 dark:text-slate-400">{t('classRatingFields.expiryDate')}</label>
+                            <input type="date" value={newExpiryDate} onChange={(e) => setNewExpiryDate(e.target.value)} className="input input-sm mt-0.5" />
+                          </div>
+                        </div>
+                        <div className="flex gap-2">
+                          <button onClick={handleUpdateRating} disabled={!newIssueDate || updateRating.isPending} className="btn-primary btn-sm text-xs">
+                            {updateRating.isPending ? t('common:saving') : t('common:save')}
+                          </button>
+                          <button onClick={() => setEditingRatingId(null)} className="btn-secondary btn-sm text-xs">{t('common:cancel')}</button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="grid grid-cols-2 sm:grid-cols-[1.2fr_1fr_1.4fr_5rem] gap-x-3 gap-y-1 px-3 py-2 items-center text-sm hover:bg-slate-50 dark:hover:bg-slate-800/40">
+                        <span className="font-medium text-slate-700 dark:text-slate-200 col-span-2 sm:col-span-1">
+                          {t(`classTypeLabels.${rating.classType}`, { defaultValue: rating.classType })}
+                        </span>
+                        <span className="text-slate-600 dark:text-slate-300">
+                          <span className="sm:hidden text-xs text-slate-400 mr-1">{t('card.issued')}:</span>
+                          {fmtDate(rating.issueDate)}
+                        </span>
+                        <span>
+                          <span className="sm:hidden text-xs text-slate-400 mr-1">{t('classRatingFields.expiryDate')}:</span>
+                          <ExpiryBadge expiryDate={rating.expiryDate} />
+                        </span>
+                        <div className="flex items-center gap-1 justify-end col-span-2 sm:col-span-1">
+                          <button
+                            onClick={() => startEditRating(rating)}
+                            className="min-w-[32px] min-h-[32px] flex items-center justify-center text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors text-xs"
+                            title={t('card.editRating')}
+                            aria-label={t('card.editRating')}
+                          >
+                            ✏
+                          </button>
+                          <button
+                            onClick={() => handleDeleteRating(rating.id)}
+                            className="min-w-[32px] min-h-[32px] flex items-center justify-center text-slate-400 hover:text-red-500 dark:hover:text-red-400 transition-colors text-xs font-bold leading-none"
+                            title={t('card.removeRating')}
+                            aria-label={t('card.removeRating')}
+                          >
+                            ✕
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
                 ))}
-              </select>
-            </div>
-            <div>
-              <label className="text-xs text-slate-500 dark:text-slate-400">{t('fields.issueDate')}</label>
-              <input
-                type="date"
-                value={newIssueDate}
-                onChange={(e) => setNewIssueDate(e.target.value)}
-                className="input input-sm mt-0.5"
-              />
-            </div>
-            <div>
-              <label className="text-xs text-slate-500 dark:text-slate-400">{t('card.expiryDateOptional')}</label>
-              <input
-                type="date"
-                value={newExpiryDate}
-                onChange={(e) => setNewExpiryDate(e.target.value)}
-                className="input input-sm mt-0.5"
-              />
-            </div>
-            <div className="flex gap-2 pt-1">
-              <button
-                onClick={handleAddRating}
-                disabled={!newIssueDate || createRating.isPending}
-                className="btn-primary btn-sm flex-1"
-              >
-                {createRating.isPending ? t('common:saving') : t('common:save')}
-              </button>
-              <button
-                onClick={() => setShowAddForm(false)}
-                className="btn-secondary btn-sm flex-1"
-              >
-                {t('common:cancel')}
-              </button>
-            </div>
-          </div>
-        ) : (
-          <button
-            onClick={() => setShowAddForm(true)}
-            className="mt-2 text-xs text-blue-600 dark:text-blue-400 hover:underline min-h-[44px] flex items-center"
-          >
-            {t('card.addRating')}
-          </button>
-        )}
-      </div>
+              </ul>
+            ) : (
+              <p className="text-xs text-slate-400 dark:text-slate-500 italic">{t('card.noClassRatings')}</p>
+            )}
 
-      <div className="flex gap-2 mt-4 pt-4 border-t border-slate-200 dark:border-slate-700">
-        <button onClick={onEdit} className="btn-secondary btn-sm flex-1">
-          {t('common:edit')}
-        </button>
-        <button
-          onClick={onDelete}
-          className="btn-secondary btn-sm flex-1 hover:bg-red-50 hover:text-red-700 hover:border-red-200 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-        >
-          {t('common:delete')}
-        </button>
+            {/* Add Rating */}
+            {showAddForm && (
+              <div className="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-2 rounded-md border border-slate-200 dark:border-slate-600 p-3 bg-slate-50 dark:bg-slate-800/50">
+                <div>
+                  <label className="text-xs text-slate-500 dark:text-slate-400">{t('card.classType')}</label>
+                  <select
+                    value={newClassType}
+                    onChange={(e) => setNewClassType(e.target.value)}
+                    className="input input-sm mt-0.5"
+                  >
+                    {CLASS_TYPE_OPTIONS.map((ct) => (
+                      <option key={ct} value={ct}>{t(`classTypeLabels.${ct}`, { defaultValue: ct })}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="text-xs text-slate-500 dark:text-slate-400">{t('fields.issueDate')}</label>
+                  <input
+                    type="date"
+                    value={newIssueDate}
+                    onChange={(e) => setNewIssueDate(e.target.value)}
+                    className="input input-sm mt-0.5"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs text-slate-500 dark:text-slate-400">{t('card.expiryDateOptional')}</label>
+                  <input
+                    type="date"
+                    value={newExpiryDate}
+                    onChange={(e) => setNewExpiryDate(e.target.value)}
+                    className="input input-sm mt-0.5"
+                  />
+                </div>
+                <div className="sm:col-span-3 flex gap-2 pt-1">
+                  <button
+                    onClick={handleAddRating}
+                    disabled={!newIssueDate || createRating.isPending}
+                    className="btn-primary btn-sm"
+                  >
+                    {createRating.isPending ? t('common:saving') : t('common:save')}
+                  </button>
+                  <button
+                    onClick={() => setShowAddForm(false)}
+                    className="btn-secondary btn-sm"
+                  >
+                    {t('common:cancel')}
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex lg:flex-col gap-2 lg:w-28 lg:shrink-0 pt-2 lg:pt-0 border-t lg:border-t-0 border-slate-100 dark:border-slate-700">
+          <button onClick={onEdit} className="btn-secondary btn-sm flex-1">
+            {t('common:edit')}
+          </button>
+          <button
+            onClick={onDelete}
+            className="btn-secondary btn-sm flex-1 hover:bg-red-50 hover:text-red-700 hover:border-red-200 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+          >
+            {t('common:delete')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/aircraft/AircraftPage.tsx
+++ b/src/pages/aircraft/AircraftPage.tsx
@@ -28,7 +28,7 @@ export default function AircraftPage() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <SkeletonGrid count={4} />
       </div>
     );
@@ -36,7 +36,7 @@ export default function AircraftPage() {
 
   if (error) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <ErrorState
           title={t('errorTitle')}
           message={t('errorMessage')}
@@ -46,8 +46,8 @@ export default function AircraftPage() {
   }
 
   return (
-    <div className="mx-auto max-w-[960px] py-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="mx-auto max-w-7xl py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <div>
           <h1 className="page-title">{t('title')}</h1>
           <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 flex items-center gap-2">
@@ -57,7 +57,7 @@ export default function AircraftPage() {
         </div>
         <button
           onClick={() => { setEditingId(null); setShowForm(true); }}
-          className="btn-primary"
+          className="btn-primary self-start sm:self-auto"
         >
           + {t('addAircraft')}
         </button>
@@ -108,85 +108,97 @@ export default function AircraftPage() {
           </button>
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-4">
           {aircraft.map((ac) => (
             <div key={ac.id} className="card">
-              {/* Header: Reg + Status */}
-              <div className="flex justify-between items-start mb-3">
-                <div className="min-w-0">
-                  <h3 className="font-semibold text-slate-800 dark:text-slate-100 truncate text-lg">
-                    {ac.registration}
-                  </h3>
-                  <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">
+              <div className="flex flex-col lg:flex-row lg:items-start gap-4 lg:gap-6">
+                {/* Identity */}
+                <div className="lg:w-72 lg:shrink-0">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100 tracking-tight">
+                      {ac.registration}
+                    </h3>
+                    <span
+                      className={`badge text-xs ${
+                        ac.isActive
+                          ? 'badge-current'
+                          : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
+                      }`}
+                    >
+                      {ac.isActive ? t('active') : t('inactive')}
+                    </span>
+                  </div>
+                  <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
                     {ac.make} {ac.model}
                   </p>
                 </div>
-                <span
-                  className={`badge text-xs shrink-0 ml-2 ${
-                    ac.isActive
-                      ? 'badge-current'
-                      : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'
-                  }`}
-                >
-                  {ac.isActive ? t('active') : t('inactive')}
-                </span>
-              </div>
 
-              {/* Details */}
-              <dl className="text-sm space-y-1.5 mb-4">
-                <div className="flex justify-between">
-                  <dt className="text-slate-500 dark:text-slate-400">{t('fields.type')}</dt>
-                  <dd className="text-slate-700 dark:text-slate-300">{ac.type}</dd>
-                </div>
-                {ac.aircraftClass && (
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500 dark:text-slate-400">{t('fields.class')}</dt>
-                    <dd className="text-slate-700 dark:text-slate-300">
-                      {t(`classes.${ac.aircraftClass}`, { defaultValue: ac.aircraftClass })}
+                {/* Specs grid */}
+                <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-2 xl:grid-cols-4 gap-x-6 gap-y-3 flex-1 text-sm min-w-0">
+                  <div>
+                    <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                      {t('fields.type')}
+                    </dt>
+                    <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                      {ac.type}
                     </dd>
                   </div>
-                )}
-                {(ac.isComplex || ac.isHighPerformance || ac.isTailwheel) && (
-                  <div className="flex flex-wrap gap-1.5 pt-1">
-                    {ac.isComplex && (
-                      <span className="badge-info">
-                        {t('fields.isComplex')}
-                      </span>
-                    )}
-                    {ac.isHighPerformance && (
-                      <span className="badge-expiring">
-                        {t('highPerf')}
-                      </span>
-                    )}
-                    {ac.isTailwheel && (
-                      <span className="badge-neutral">
-                        {t('fields.isTailwheel')}
-                      </span>
-                    )}
+                  {ac.aircraftClass && (
+                    <div>
+                      <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {t('fields.class')}
+                      </dt>
+                      <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                        {t(`classes.${ac.aircraftClass}`, { defaultValue: ac.aircraftClass })}
+                      </dd>
+                    </div>
+                  )}
+                  <div className="col-span-2 sm:col-span-1 lg:col-span-2 xl:col-span-2">
+                    <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                      {t('form.characteristics')}
+                    </dt>
+                    <dd className="mt-1 flex flex-wrap gap-1.5">
+                      {ac.isComplex && (
+                        <span className="badge-info">{t('fields.isComplex')}</span>
+                      )}
+                      {ac.isHighPerformance && (
+                        <span className="badge-expiring">{t('highPerf')}</span>
+                      )}
+                      {ac.isTailwheel && (
+                        <span className="badge-neutral">{t('fields.isTailwheel')}</span>
+                      )}
+                      {!ac.isComplex && !ac.isHighPerformance && !ac.isTailwheel && (
+                        <span className="text-xs text-slate-400 dark:text-slate-500">—</span>
+                      )}
+                    </dd>
                   </div>
-                )}
-              </dl>
+                  {ac.notes && (
+                    <div className="col-span-2 sm:col-span-3 lg:col-span-2 xl:col-span-4">
+                      <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {t('fields.notes', { defaultValue: 'Notes' })}
+                      </dt>
+                      <dd className="mt-0.5 text-slate-600 dark:text-slate-300 italic break-words">
+                        {ac.notes}
+                      </dd>
+                    </div>
+                  )}
+                </dl>
 
-              {ac.notes && (
-                <p className="text-xs text-slate-500 dark:text-slate-400 italic mb-3 truncate">
-                  {ac.notes}
-                </p>
-              )}
-
-              {/* Actions */}
-              <div className="flex gap-2 pt-2 border-t border-slate-100 dark:border-slate-700">
-                <button
-                  onClick={() => { setEditingId(ac.id); setShowForm(true); }}
-                  className="btn-ghost btn-sm flex-1"
-                >
-                  {t('edit')}
-                </button>
-                <button
-                  onClick={() => handleDelete(ac.id)}
-                  className="btn-ghost btn-sm flex-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-                >
-                  {t('delete')}
-                </button>
+                {/* Actions */}
+                <div className="flex lg:flex-col gap-2 lg:w-28 lg:shrink-0 pt-2 lg:pt-0 border-t lg:border-t-0 border-slate-100 dark:border-slate-700">
+                  <button
+                    onClick={() => { setEditingId(ac.id); setShowForm(true); }}
+                    className="btn-ghost btn-sm flex-1"
+                  >
+                    {t('edit')}
+                  </button>
+                  <button
+                    onClick={() => handleDelete(ac.id)}
+                    className="btn-ghost btn-sm flex-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                  >
+                    {t('delete')}
+                  </button>
+                </div>
               </div>
             </div>
           ))}

--- a/src/pages/credentials/CredentialsPage.tsx
+++ b/src/pages/credentials/CredentialsPage.tsx
@@ -42,7 +42,7 @@ export default function CredentialsPage() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <SkeletonGrid count={4} />
       </div>
     );
@@ -50,7 +50,7 @@ export default function CredentialsPage() {
 
   if (error) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <ErrorState
           title="Failed to load credentials"
           message="An error occurred while loading your credentials. Please try again."
@@ -60,8 +60,8 @@ export default function CredentialsPage() {
   }
 
   return (
-    <div className="mx-auto max-w-[960px] py-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="mx-auto max-w-7xl py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <div>
           <h1 className="page-title">{t('title')}</h1>
           <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 flex items-center gap-2">
@@ -69,7 +69,7 @@ export default function CredentialsPage() {
             <HelpLink topic="credentials" />
           </p>
         </div>
-        <button onClick={() => { setEditingId(null); setShowForm(true); }} className="btn-primary">
+        <button onClick={() => { setEditingId(null); setShowForm(true); }} className="btn-primary self-start sm:self-auto">
           {t('addCredential')}
         </button>
       </div>
@@ -118,59 +118,84 @@ export default function CredentialsPage() {
           </button>
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-4">
           {credentials.map((cred) => {
             const status = getExpiryStatus(cred.expiryDate);
             return (
               <div key={cred.id} className="card">
-                <div className="flex justify-between items-start mb-3">
-                  <div className="min-w-0">
-                    <h3 className="font-semibold text-slate-800 dark:text-slate-100 truncate">
-                      {t(`types.${cred.credentialType}`, { defaultValue: cred.credentialType })}
-                    </h3>
-                    {cred.credentialNumber && (
-                      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{cred.credentialNumber}</p>
-                    )}
-                  </div>
-                  <span className={`badge text-xs shrink-0 ml-2 ${status.class}`}>
-                    {status.label}
-                  </span>
-                </div>
-
-                <dl className="text-sm space-y-1.5 mb-4">
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500 dark:text-slate-400">{t('issued')}</dt>
-                    <dd className="text-slate-700 dark:text-slate-300">{fmtDate(cred.issueDate)}</dd>
-                  </div>
-                  {cred.expiryDate && (
-                    <div className="flex justify-between">
-                      <dt className="text-slate-500 dark:text-slate-400">{t('expires')}</dt>
-                      <dd className="text-slate-700 dark:text-slate-300">{fmtDate(cred.expiryDate)}</dd>
+                <div className="flex flex-col lg:flex-row lg:items-start gap-4 lg:gap-6">
+                  {/* Identity */}
+                  <div className="lg:w-80 lg:shrink-0">
+                    <div className="flex items-start gap-3 flex-wrap">
+                      <div className="min-w-0">
+                        <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+                          {t(`types.${cred.credentialType}`, { defaultValue: cred.credentialType })}
+                        </h3>
+                        {cred.credentialNumber && (
+                          <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 font-mono">
+                            {cred.credentialNumber}
+                          </p>
+                        )}
+                      </div>
+                      <span className={`badge text-xs ${status.class}`}>
+                        {status.label}
+                      </span>
                     </div>
-                  )}
-                  <div className="flex justify-between">
-                    <dt className="text-slate-500 dark:text-slate-400">{t('authority')}</dt>
-                    <dd className="text-slate-700 dark:text-slate-300">{cred.issuingAuthority}</dd>
                   </div>
-                </dl>
 
-                {cred.notes && (
-                  <p className="text-xs text-slate-500 dark:text-slate-400 italic mb-3 truncate">{cred.notes}</p>
-                )}
+                  {/* Details grid */}
+                  <dl className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-3 gap-x-6 gap-y-3 flex-1 text-sm min-w-0">
+                    <div>
+                      <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {t('issued')}
+                      </dt>
+                      <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                        {fmtDate(cred.issueDate)}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {t('expires')}
+                      </dt>
+                      <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200">
+                        {cred.expiryDate ? fmtDate(cred.expiryDate) : '—'}
+                      </dd>
+                    </div>
+                    <div className="col-span-2 sm:col-span-1">
+                      <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                        {t('authority')}
+                      </dt>
+                      <dd className="mt-0.5 font-medium text-slate-700 dark:text-slate-200 break-words">
+                        {cred.issuingAuthority}
+                      </dd>
+                    </div>
+                    {cred.notes && (
+                      <div className="col-span-2 sm:col-span-3">
+                        <dt className="text-xs uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                          {t('fields.notes')}
+                        </dt>
+                        <dd className="mt-0.5 text-slate-600 dark:text-slate-300 italic break-words">
+                          {cred.notes}
+                        </dd>
+                      </div>
+                    )}
+                  </dl>
 
-                <div className="flex gap-2 pt-2 border-t border-slate-100 dark:border-slate-700">
-                  <button
-                    onClick={() => { setEditingId(cred.id); setShowForm(true); }}
-                    className="btn-ghost btn-sm flex-1"
-                  >
-                    {t('edit')}
-                  </button>
-                  <button
-                    onClick={() => handleDelete(cred.id)}
-                    className="btn-ghost btn-sm flex-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
-                  >
-                    {t('delete')}
-                  </button>
+                  {/* Actions */}
+                  <div className="flex lg:flex-col gap-2 lg:w-28 lg:shrink-0 pt-2 lg:pt-0 border-t lg:border-t-0 border-slate-100 dark:border-slate-700">
+                    <button
+                      onClick={() => { setEditingId(cred.id); setShowForm(true); }}
+                      className="btn-ghost btn-sm flex-1"
+                    >
+                      {t('edit')}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(cred.id)}
+                      className="btn-ghost btn-sm flex-1 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    >
+                      {t('delete')}
+                    </button>
+                  </div>
                 </div>
               </div>
             );

--- a/src/pages/licenses/LicensesPage.tsx
+++ b/src/pages/licenses/LicensesPage.tsx
@@ -37,12 +37,12 @@ export default function LicensesPage() {
 
   if (isLoading) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <div className="animate-pulse space-y-4">
           <div className="h-8 bg-slate-200 dark:bg-slate-700 rounded w-48"></div>
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          <div className="flex flex-col gap-4">
             {[1, 2, 3].map((i) => (
-              <div key={i} className="card h-48">
+              <div key={i} className="card h-40">
                 <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded w-3/4 mb-3"></div>
                 <div className="h-3 bg-slate-200 dark:bg-slate-700 rounded w-1/2 mb-2"></div>
                 <div className="h-3 bg-slate-200 dark:bg-slate-700 rounded w-2/3"></div>
@@ -56,7 +56,7 @@ export default function LicensesPage() {
 
   if (error) {
     return (
-      <div className="mx-auto max-w-[960px] py-6">
+      <div className="mx-auto max-w-7xl py-6">
         <div className="card text-center py-12">
           <div className="text-4xl mb-3">⚠</div>
           <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-100 mb-2">{t('error')}</h2>
@@ -67,13 +67,13 @@ export default function LicensesPage() {
   }
 
   return (
-    <div className="mx-auto max-w-[960px] py-6">
-      <div className="flex items-center justify-between mb-6">
+    <div className="mx-auto max-w-7xl py-6">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
         <div className="flex items-center gap-2">
           <h1 className="page-title">{t('title')}</h1>
           <HelpLink topic="licenses" />
         </div>
-        <button onClick={() => setShowForm(true)} className="btn-primary">
+        <button onClick={() => setShowForm(true)} className="btn-primary self-start sm:self-auto">
           {t('addLicense')}
         </button>
       </div>
@@ -113,7 +113,7 @@ export default function LicensesPage() {
           </button>
         </div>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="flex flex-col gap-4">
           {licenses?.map((license) => (
             <LicenseCard
               key={license.id}


### PR DESCRIPTION
## Summary

Refactors the **Aircraft**, **Licenses**, and **Credentials** views to use full-width cards that take advantage of the available screen real estate on desktop while remaining clean on mobile. Frontend-only — no API or behavior changes.

## Changes

- Page containers bumped from `max-w-[960px]` to `max-w-7xl`.
- Multi-column card grids replaced with a single-column stack of full-width cards.
- Each card uses a 3-zone layout that adapts responsively:
  1. **Identity** — primary heading + status badge + secondary line (registration / make+model, license type / number, credential type / number).
  2. **Details grid** — responsive `dl` (2 / 3 / 4 columns) with uppercase labels and emphasized values, so all fields (including notes) are visible without truncation.
  3. **Actions** — Edit/Delete stacked vertically on desktop, side-by-side on mobile.

### Per-view notes

- **AircraftPage** — characteristics shown as a labeled badge group; notes get a full-width row.
- **CredentialsPage** — issued / expires / authority shown as 3 columns; notes span full row.
- **LicenseCard** — class ratings now render as a proper bordered list with a header row (Class · Issued · Expires · actions); header and data rows share the same grid template (`1.2fr 1fr 1.4fr 5rem`) so columns align. The issue date is now visible alongside the expiry. "Separate logbook" badge moved into the identity zone.
- **ExpiryBadge** — always shows the formatted expiry date (per the user's date-format preference), with a colored status pill alongside it when expired or expiring within 30 days.

## Compatibility

Existing test selectors are preserved:
- `card` className still on each item card.
- `Edit` / `Delete` button labels unchanged.
- Headings, registration text, "make + model" composite text, and notes content unchanged.

## Tests

- ✅ All 263 frontend unit tests pass.
- ✅ Full Playwright e2e suite passes (80 passed, 3 skipped, 1 flaky retry — pre-existing race in `createTestUser` helper, unrelated).