### PR TITLE
fix(frontend): prevent blank screen after login on stale chunks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,31 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from './stores/authStore';
 import { useTheme } from './hooks/useTheme';
 import { bootstrapPromise } from './api/client';
 import Layout from './components/layout/Layout';
+import { lazyWithRetry } from './lib/lazyWithRetry';
 
-// Lazy-loaded pages for code splitting
-const LoginPage = lazy(() => import('./pages/auth/LoginPage'));
-const RegisterPage = lazy(() => import('./pages/auth/RegisterPage'));
-const ResetPasswordPage = lazy(() => import('./pages/auth/ResetPasswordPage'));
-const NewPasswordPage = lazy(() => import('./pages/auth/NewPasswordPage'));
-const DashboardPage = lazy(() => import('./pages/DashboardPage'));
-const LicensesPage = lazy(() => import('./pages/licenses/LicensesPage'));
-const FlightsPage = lazy(() => import('./pages/flights/FlightsPage'));
-const FlightDetailPage = lazy(() => import('./pages/flights/FlightDetailPage'));
-const ProfilePage = lazy(() => import('./pages/ProfilePage'));
-const CredentialsPage = lazy(() => import('./pages/credentials/CredentialsPage'));
-const AircraftPage = lazy(() => import('./pages/aircraft/AircraftPage'));
-const ReportsPage = lazy(() => import('./pages/reports/ReportsPage'));
-const MapPage = lazy(() => import('./pages/maps/MapPage'));
-const ImportPage = lazy(() => import('./pages/import/ImportPage'));
-const ExportPage = lazy(() => import('./pages/export/ExportPage'));
-const CurrencyPage = lazy(() => import('./pages/currency/CurrencyPage'));
-const AdminPage = lazy(() => import('./pages/admin/AdminPage'));
-const HelpPage = lazy(() => import('./pages/help/HelpPage'));
+// Lazy-loaded pages for code splitting (with chunk-load retry + reload fallback
+// so a stale PWA deployment never strands the user on a blank screen).
+const LoginPage = lazyWithRetry(() => import('./pages/auth/LoginPage'));
+const RegisterPage = lazyWithRetry(() => import('./pages/auth/RegisterPage'));
+const ResetPasswordPage = lazyWithRetry(() => import('./pages/auth/ResetPasswordPage'));
+const NewPasswordPage = lazyWithRetry(() => import('./pages/auth/NewPasswordPage'));
+const DashboardPage = lazyWithRetry(() => import('./pages/DashboardPage'));
+const LicensesPage = lazyWithRetry(() => import('./pages/licenses/LicensesPage'));
+const FlightsPage = lazyWithRetry(() => import('./pages/flights/FlightsPage'));
+const FlightDetailPage = lazyWithRetry(() => import('./pages/flights/FlightDetailPage'));
+const ProfilePage = lazyWithRetry(() => import('./pages/ProfilePage'));
+const CredentialsPage = lazyWithRetry(() => import('./pages/credentials/CredentialsPage'));
+const AircraftPage = lazyWithRetry(() => import('./pages/aircraft/AircraftPage'));
+const ReportsPage = lazyWithRetry(() => import('./pages/reports/ReportsPage'));
+const MapPage = lazyWithRetry(() => import('./pages/maps/MapPage'));
+const ImportPage = lazyWithRetry(() => import('./pages/import/ImportPage'));
+const ExportPage = lazyWithRetry(() => import('./pages/export/ExportPage'));
+const CurrencyPage = lazyWithRetry(() => import('./pages/currency/CurrencyPage'));
+const AdminPage = lazyWithRetry(() => import('./pages/admin/AdminPage'));
+const HelpPage = lazyWithRetry(() => import('./pages/help/HelpPage'));
 
 function PageLoader() {
   return (

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,83 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { isChunkLoadError } from '../lib/lazyWithRetry';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Top-level error boundary. Without this, a rejected dynamic `import()` from a
+ * lazy-loaded route (very common after a PWA redeploy) unmounts the entire
+ * tree and leaves the user on a blank white screen forever — most visibly
+ * right after login, when `/dashboard` is the first never-fetched chunk.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Log to console — surfaces in DevTools and the iOS Web Inspector.
+    // eslint-disable-next-line no-console
+    console.error('[ErrorBoundary]', error, info);
+  }
+
+  private handleReload = (): void => {
+    try {
+      sessionStorage.removeItem('ninerlog:chunk-reloaded');
+    } catch {
+      /* ignore */
+    }
+    window.location.reload();
+  };
+
+  private handleGoHome = (): void => {
+    try {
+      sessionStorage.removeItem('ninerlog:chunk-reloaded');
+    } catch {
+      /* ignore */
+    }
+    window.location.href = '/';
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const isChunk = isChunkLoadError(error);
+    const title = isChunk ? 'Update available' : 'Something went wrong';
+    const message = isChunk
+      ? 'A newer version of NinerLog is available. Reload to continue.'
+      : 'The app hit an unexpected error. Reloading usually fixes it.';
+
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4 bg-slate-50 dark:bg-slate-900">
+        <div
+          role="alert"
+          className="card max-w-md w-full text-center py-10"
+        >
+          <h1 className="text-2xl font-semibold text-slate-800 dark:text-slate-100 mb-2">
+            {title}
+          </h1>
+          <p className="text-slate-500 dark:text-slate-400 mb-6">
+            {message}
+          </p>
+          <div className="flex gap-3 justify-center">
+            <button onClick={this.handleReload} className="btn-primary">
+              Reload
+            </button>
+            <button onClick={this.handleGoHome} className="btn-ghost">
+              Go to home
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/lib/lazyWithRetry.ts
+++ b/src/lib/lazyWithRetry.ts
@@ -1,0 +1,60 @@
+import { lazy, type ComponentType } from 'react';
+
+/**
+ * Detects errors thrown by a failed dynamic `import()` (chunk load failure).
+ *
+ * These typically happen when the deployed bundle has new chunk hashes but the
+ * user's tab still references the old `index.html`. The PWA service worker
+ * (autoUpdate) makes this more frequent: after a deploy, navigating to a route
+ * whose chunk has never been fetched can 404 / fail with a MIME-type error.
+ */
+export function isChunkLoadError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as { name?: string; message?: string; code?: string };
+  const msg = (e.message || '').toLowerCase();
+  return (
+    e.name === 'ChunkLoadError' ||
+    e.code === 'CSS_CHUNK_LOAD_FAILED' ||
+    msg.includes('failed to fetch dynamically imported module') ||
+    msg.includes('error loading dynamically imported module') ||
+    msg.includes('importing a module script failed') ||
+    msg.includes('unknown variable dynamic import') ||
+    // Safari sometimes surfaces a generic message for SSL/network blips
+    msg.includes("'text/html' is not a valid javascript mime type")
+  );
+}
+
+/**
+ * Wraps `React.lazy` with one automatic retry on dynamic-import failure, then
+ * forces a hard reload (once) so the browser fetches the fresh `index.html`
+ * with current chunk hashes. A sessionStorage flag prevents reload loops.
+ */
+export function lazyWithRetry<T extends ComponentType<unknown>>(
+  factory: () => Promise<{ default: T }>
+): ReturnType<typeof lazy<T>> {
+  return lazy(async () => {
+    const RELOAD_KEY = 'ninerlog:chunk-reloaded';
+    try {
+      return await factory();
+    } catch (err) {
+      if (!isChunkLoadError(err)) throw err;
+      // Retry once — covers transient network glitches.
+      try {
+        return await factory();
+      } catch (err2) {
+        if (!isChunkLoadError(err2)) throw err2;
+        // Force a single reload to pick up the new index.html / chunks. The
+        // ErrorBoundary handles the case where reload didn't help (offline,
+        // truly broken deploy) and shows a Retry button.
+        if (typeof window !== 'undefined' && !sessionStorage.getItem(RELOAD_KEY)) {
+          sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+          window.location.reload();
+          // Return a never-resolving promise so Suspense keeps the loader up
+          // until the page actually reloads, instead of flashing an error.
+          return new Promise<{ default: T }>(() => {});
+        }
+        throw err2;
+      }
+    }
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter } from 'react-router-dom';
 import { BetaGate } from './components/BetaGate';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import App from './App';
 import './index.css';
 import './i18n'; // i18n initialization — must be imported before App
@@ -20,13 +21,15 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <BetaGate>
-      <QueryClientProvider client={queryClient}>
-        <BrowserRouter>
-          <App />
-        </BrowserRouter>
-      </QueryClientProvider>
-    </BetaGate>
+    <ErrorBoundary>
+      <BetaGate>
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <App />
+          </BrowserRouter>
+        </QueryClientProvider>
+      </BetaGate>
+    </ErrorBoundary>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
## Problem

Users sometimes saw a blank white screen forever after logging in.

## Root cause

Every route in `src/App.tsx` is loaded with `React.lazy()`, but the app had **no `ErrorBoundary` anywhere** in the tree. Combined with the PWA's `registerType: 'autoUpdate'`, this is what happened after a redeploy:

1. The user's tab still references the old `index.html` (and its old chunk hashes).
2. After login, `navigate('/dashboard')` triggers `import('./pages/DashboardPage')`.
3. That dynamic import 404s on the now-deleted chunk.
4. `Suspense` re-throws the rejected promise.
5. With no error boundary above it, React unmounts the entire tree → blank screen, no recovery.

The dashboard chunk is the most common victim because it's the first never-before-loaded chunk after login, but the same bug affects every lazy route.

## Fix

- **`src/lib/lazyWithRetry.ts`** — drop-in replacement for `React.lazy` that:
  - retries the import once on `ChunkLoadError` (covers transient network glitches), then
  - forces a single hard reload (guarded by a `sessionStorage` flag against reload loops) so the browser fetches a fresh `index.html` with current chunk hashes.
- **`src/components/ErrorBoundary.tsx`** — top-level boundary that detects chunk-load errors via `name === 'ChunkLoadError'` and message heuristics, and renders a friendly **Reload / Go to home** UI instead of a blank screen. Also catches any other render-time error so users always have a recovery path.
- All 18 lazy-loaded routes in `src/App.tsx` switched from `lazy(...)` to `lazyWithRetry(...)`.
- `src/main.tsx` wraps the entire app in `<ErrorBoundary>`.

## Commits

1. `feat(frontend): add ErrorBoundary and lazyWithRetry helper` — pure additions, no wiring.
2. `fix(frontend): prevent blank screen after login on stale chunks` — wires the new infra into `App.tsx` and `main.tsx`.

## Tests

- ✅ Unit tests: 263 passed (27 files) — `npx vitest run`
- ✅ E2E tests: 81 passed, 3 skipped, 0 failed — `bash scripts/run-all-tests.sh` (full Docker suite)

No API changes, no OpenAPI updates needed.