### PR TITLE
feat(admin): delete-user button with email-confirmation modal

### DIFF
--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -1212,6 +1212,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/users/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Permanently delete a user account
+         * @description Permanently delete a user account and ALL their content (flights, aircraft,
+         *     licenses, contacts, credentials, backups, notifications, etc.) via cascading
+         *     deletes. This action is irreversible. The deletion is recorded in the admin
+         *     audit log (with the target user reference set to NULL after the cascade).
+         *     An admin cannot delete their own account.
+         */
+        delete: operations["deleteUser"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/admin/users/{userId}/disable": {
         parameters: {
             query?: never;
@@ -5731,6 +5755,34 @@ export interface operations {
             };
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+        };
+    };
+    deleteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User and all their content deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message?: string;
+                    };
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
         };
     };
     disableUser: {

--- a/src/hooks/useAdmin.ts
+++ b/src/hooks/useAdmin.ts
@@ -87,6 +87,23 @@ export const useResetUser2fa = () => {
   });
 };
 
+export const useDeleteUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (userId: string) => {
+      const { data, error } = await apiClient.DELETE('/admin/users/{userId}', {
+        params: { path: { userId } },
+      });
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'stats'] });
+    },
+  });
+};
+
 export const useAdminStats = () => {
   return useQuery({
     queryKey: ['admin', 'stats'],

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -144,11 +144,16 @@
       "enableConfirm": "Konto für {{email}} wieder aktivieren?",
       "unlockConfirm": "Konto für {{email}} entsperren?",
       "reset2faConfirm": "2FA für {{email}} zurücksetzen?",
+      "deleteConfirm": "Konto für {{email}} dauerhaft löschen?",
+      "deleteWarning": "Dies löscht {{name}} und ALLE Inhalte ({{flightCount}} Flüge, {{aircraftCount}} Flugzeuge sowie Lizenzen, Kontakte, Berechtigungen, Backups und Benachrichtigungen) dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "deleteEmailPrompt": "Geben Sie {{email}} ein, um die Löschung zu bestätigen",
+      "deleteTitle": "Konto und alle Inhalte löschen",
       "auditTrailNote": "Diese Aktion wird im Admin-Audit-Protokoll erfasst.",
       "disable": "Deaktivieren",
       "enable": "Aktivieren",
       "unlock": "Entsperren",
-      "reset2fa": "2FA zurücksetzen"
+      "reset2fa": "2FA zurücksetzen",
+      "delete": "Löschen"
     },
     "audit": {
       "timestamp": "Zeitstempel",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -144,11 +144,16 @@
       "enableConfirm": "Re-enable account for {{email}}?",
       "unlockConfirm": "Unlock account for {{email}}?",
       "reset2faConfirm": "Reset 2FA for {{email}}?",
+      "deleteConfirm": "Permanently delete the account for {{email}}?",
+      "deleteWarning": "This will permanently delete {{name}} and ALL of their content ({{flightCount}} flights, {{aircraftCount}} aircraft, plus licenses, contacts, credentials, backups, and notifications). This action cannot be undone.",
+      "deleteEmailPrompt": "Type {{email}} to confirm deletion",
+      "deleteTitle": "Delete account and all content",
       "auditTrailNote": "This action will be logged to the admin audit trail.",
       "disable": "Disable",
       "enable": "Enable",
       "unlock": "Unlock",
-      "reset2fa": "Reset 2FA"
+      "reset2fa": "Reset 2FA",
+      "delete": "Delete"
     },
     "audit": {
       "timestamp": "Timestamp",

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../../stores/authStore';
 import { ShieldCheck, Search, Ban, CheckCircle, Unlock, KeyRound, Users, BarChart3, Wrench, ScrollText, Settings2, Megaphone, Trash2 } from 'lucide-react';
 import {
-  useAdminUsers, useDisableUser, useEnableUser, useUnlockUser, useResetUser2fa,
+  useAdminUsers, useDisableUser, useEnableUser, useUnlockUser, useResetUser2fa, useDeleteUser,
   useAdminStats, useAdminAuditLog, useCleanupTokens, useSmtpTest, useAdminConfig,
 } from '../../hooks/useAdmin';
 import { useCreateAnnouncement, useDeleteAnnouncement, useAnnouncements } from '../../hooks/useAnnouncements';
@@ -122,6 +122,7 @@ function UsersTab() {
   const [search, setSearch] = useState('');
   const [searchInput, setSearchInput] = useState('');
   const [confirmAction, setConfirmAction] = useState<{ type: string; user: AdminUser } | null>(null);
+  const [deleteEmailInput, setDeleteEmailInput] = useState('');
   const [actionMessage, setActionMessage] = useState('');
 
   const { data, isLoading } = useAdminUsers(page, 20, search || undefined);
@@ -129,9 +130,13 @@ function UsersTab() {
   const enableUser = useEnableUser();
   const unlockUser = useUnlockUser();
   const resetUser2fa = useResetUser2fa();
+  const deleteUser = useDeleteUser();
 
   const handleAction = async () => {
     if (!confirmAction) return;
+    if (confirmAction.type === 'delete' && deleteEmailInput.trim().toLowerCase() !== confirmAction.user.email.toLowerCase()) {
+      return;
+    }
     setActionMessage('');
     try {
       const fns: Record<string, (id: string) => Promise<unknown>> = {
@@ -139,15 +144,17 @@ function UsersTab() {
         enable: (id) => enableUser.mutateAsync(id),
         unlock: (id) => unlockUser.mutateAsync(id),
         'reset-2fa': (id) => resetUser2fa.mutateAsync(id),
+        delete: (id) => deleteUser.mutateAsync(id),
       };
       await fns[confirmAction.type](confirmAction.user.id);
       setActionMessage(`Action "${confirmAction.type}" applied to ${confirmAction.user.email}.`);
     } catch { setActionMessage(`Failed to ${confirmAction.type} user.`); }
     setConfirmAction(null);
+    setDeleteEmailInput('');
   };
 
   const handleSearch = (e: React.FormEvent) => { e.preventDefault(); setSearch(searchInput); setPage(1); };
-  const actionLabel = (type: string) => type === 'disable' ? t('admin.users.disable') : type === 'enable' ? t('admin.users.enable') : type === 'unlock' ? t('admin.users.unlock') : t('admin.users.reset2fa');
+  const actionLabel = (type: string) => type === 'disable' ? t('admin.users.disable') : type === 'enable' ? t('admin.users.enable') : type === 'unlock' ? t('admin.users.unlock') : type === 'delete' ? t('admin.users.delete') : t('admin.users.reset2fa');
 
   return (
     <>
@@ -191,6 +198,7 @@ function UsersTab() {
                       : <button onClick={() => setConfirmAction({ type: 'disable', user: u })} className="btn-ghost btn-sm text-xs text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20" title="Disable account"><Ban className="w-3.5 h-3.5" /></button>}
                     {u.locked && <button onClick={() => setConfirmAction({ type: 'unlock', user: u })} className="btn-ghost btn-sm text-xs text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20" title="Unlock account"><Unlock className="w-3.5 h-3.5" /></button>}
                     {u.twoFactorEnabled && <button onClick={() => setConfirmAction({ type: 'reset-2fa', user: u })} className="btn-ghost btn-sm text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20" title="Reset 2FA"><KeyRound className="w-3.5 h-3.5" /></button>}
+                    <button onClick={() => setConfirmAction({ type: 'delete', user: u })} className="btn-ghost btn-sm text-xs text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20" title={t('admin.users.deleteTitle')}><Trash2 className="w-3.5 h-3.5" /></button>
                   </div></td>
                 </tr>
               ))}
@@ -222,6 +230,7 @@ function UsersTab() {
                   : <button onClick={() => setConfirmAction({ type: 'disable', user: u })} className="btn-ghost btn-sm text-xs text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20" title="Disable account"><Ban className="w-3.5 h-3.5" /></button>}
                 {u.locked && <button onClick={() => setConfirmAction({ type: 'unlock', user: u })} className="btn-ghost btn-sm text-xs text-amber-600 hover:bg-amber-50 dark:hover:bg-amber-900/20" title="Unlock account"><Unlock className="w-3.5 h-3.5" /></button>}
                 {u.twoFactorEnabled && <button onClick={() => setConfirmAction({ type: 'reset-2fa', user: u })} className="btn-ghost btn-sm text-xs text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/20" title="Reset 2FA"><KeyRound className="w-3.5 h-3.5" /></button>}
+                <button onClick={() => setConfirmAction({ type: 'delete', user: u })} className="btn-ghost btn-sm text-xs text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20" title={t('admin.users.deleteTitle')}><Trash2 className="w-3.5 h-3.5" /></button>
               </div>
             </div>
           ))}
@@ -237,7 +246,7 @@ function UsersTab() {
           </div>)}
       </div>
       {confirmAction && (<>
-        <div className="fixed inset-0 bg-black/40 z-[1020]" onClick={() => setConfirmAction(null)} />
+        <div className="fixed inset-0 bg-black/40 z-[1020]" onClick={() => { setConfirmAction(null); setDeleteEmailInput(''); }} />
         <div className="fixed inset-x-4 top-1/2 -translate-y-1/2 z-[1020] mx-auto max-w-md bg-white dark:bg-slate-800 rounded-xl shadow-2xl p-6">
           <h3 className="text-lg font-semibold text-slate-800 dark:text-slate-100 mb-2">{t('admin.users.confirmAction', { action: actionLabel(confirmAction.type) })}</h3>
           <p className="text-sm text-slate-600 dark:text-slate-400 mb-1">
@@ -245,11 +254,37 @@ function UsersTab() {
             {confirmAction.type === 'enable' && t('admin.users.enableConfirm', { email: confirmAction.user.email })}
             {confirmAction.type === 'unlock' && t('admin.users.unlockConfirm', { email: confirmAction.user.email })}
             {confirmAction.type === 'reset-2fa' && t('admin.users.reset2faConfirm', { email: confirmAction.user.email })}
+            {confirmAction.type === 'delete' && t('admin.users.deleteConfirm', { email: confirmAction.user.email })}
           </p>
+          {confirmAction.type === 'delete' && (
+            <>
+              <p className="text-xs text-red-600 dark:text-red-400 mb-3 font-medium">
+                {t('admin.users.deleteWarning', { name: confirmAction.user.name, flightCount: confirmAction.user.flightCount, aircraftCount: confirmAction.user.aircraftCount })}
+              </p>
+              <label className="block text-xs font-medium text-slate-600 dark:text-slate-300 mb-1" htmlFor="delete-confirm-email">
+                {t('admin.users.deleteEmailPrompt', { email: confirmAction.user.email })}
+              </label>
+              <input
+                id="delete-confirm-email"
+                type="text"
+                autoComplete="off"
+                autoFocus
+                value={deleteEmailInput}
+                onChange={(e) => setDeleteEmailInput(e.target.value)}
+                placeholder={confirmAction.user.email}
+                className="input mb-3"
+                aria-label={t('admin.users.deleteEmailPrompt', { email: confirmAction.user.email })}
+              />
+            </>
+          )}
           <p className="text-xs text-slate-400 mb-4">{t('admin.users.auditTrailNote')}</p>
           <div className="flex gap-3 justify-end">
-            <button onClick={() => setConfirmAction(null)} className="btn-secondary text-sm">{t('common:cancel')}</button>
-            <button onClick={handleAction} className={confirmAction.type === 'disable' ? 'btn-danger' : 'btn-primary'}>{actionLabel(confirmAction.type)}</button>
+            <button onClick={() => { setConfirmAction(null); setDeleteEmailInput(''); }} className="btn-secondary text-sm">{t('common:cancel')}</button>
+            <button
+              onClick={handleAction}
+              disabled={confirmAction.type === 'delete' && deleteEmailInput.trim().toLowerCase() !== confirmAction.user.email.toLowerCase()}
+              className={confirmAction.type === 'disable' || confirmAction.type === 'delete' ? 'btn-danger' : 'btn-primary'}
+            >{actionLabel(confirmAction.type)}</button>
           </div>
         </div>
       </>)}


### PR DESCRIPTION
## Summary

Adds a destructive **Delete** action to the admin Users tab so admins can permanently remove a user account and all of their content, complementing the existing disable/enable workflow. The action is gated by an explicit email-typed confirmation to prevent accidents.

## UX

- New trash-icon button on every user row (desktop table and mobile card).
- Opens the existing confirmation modal in a new `delete` mode that:
  - Shows a destructive warning naming the user and the volume of data that will be removed (flights, aircraft, plus licenses, contacts, credentials, backups, notifications).
  - Renders an autofocused input asking the admin to **type the target user's email** to confirm.
  - Keeps the **Delete** button disabled until the typed value matches the email exactly (case-insensitive).
  - Resets the typed email when cancelled or when the backdrop is clicked.
- Reuses the danger button styling shared with the Disable action.

## Implementation

Three logical commits:

1. `feat(api-client)` — regenerate `schema.ts` from the OpenAPI spec to include the new `deleteUser` operation, and add a `useDeleteUser` mutation hook (invalidates the admin users + stats query caches on success).
2. `feat(i18n)` — new English and German strings (`deleteConfirm`, `deleteWarning`, `deleteEmailPrompt`, `deleteTitle`, `delete`).
3. `feat(admin)` — wire the delete button + email-confirmation logic into `AdminPage.tsx`.

## Tests

- `npx tsc --noEmit` — clean.
- `npx vitest run` — 263 / 263 passing (incl. existing admin tests).
- `npx playwright test` (in docker) — 81 / 81 passing.

## Dependency

Depends on the matching backend PR adding `DELETE /admin/users/{userId}` in `ninerlog-api`. After that PR merges, `bash scripts/generate-api-client.sh` (which fetches the spec from `main` by default) will be a no-op against this branch.