### PR TITLE
feat: per-user initial-hours baseline UI

### DIFF
--- a/src/__tests__/profile/BaselineSection.test.tsx
+++ b/src/__tests__/profile/BaselineSection.test.tsx
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BaselineSection } from '../../components/profile/BaselineSection';
+
+vi.mock('../../hooks/useBaseline', () => {
+  return {
+    useMyBaseline: vi.fn(() => ({ data: null, isLoading: false })),
+    useUpsertBaseline: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useDeleteBaseline: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  };
+});
+
+import {
+  useDeleteBaseline,
+  useMyBaseline,
+  useUpsertBaseline,
+} from '../../hooks/useBaseline';
+
+const renderWithClient = (ui: React.ReactElement) => {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+};
+
+describe('BaselineSection', () => {
+  it('renders create CTA when no baseline exists', () => {
+    vi.mocked(useMyBaseline).mockReturnValue({ data: null, isLoading: false } as any);
+    vi.mocked(useUpsertBaseline).mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+    vi.mocked(useDeleteBaseline).mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+
+    renderWithClient(<BaselineSection />);
+
+    expect(screen.getByRole('button', { name: /add initial snapshot/i })).toBeInTheDocument();
+  });
+
+  it('shows summary when baseline exists', () => {
+    vi.mocked(useMyBaseline).mockReturnValue({
+      data: {
+        baselineDate: '2024-01-01',
+        totalFlights: 150,
+        totalMinutes: 6000,
+        picMinutes: 4800,
+        landingsDay: 200,
+        landingsNight: 10,
+        createdAt: '2024-01-02T00:00:00Z',
+        updatedAt: '2024-01-02T00:00:00Z',
+      },
+      isLoading: false,
+    } as any);
+
+    renderWithClient(<BaselineSection />);
+
+    expect(screen.getByText(/100\.0h total · 80\.0h PIC · 210 landings, as of 2024-01-01/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit snapshot/i })).toBeInTheDocument();
+  });
+
+  it('submits a new snapshot converting hours to minutes', async () => {
+    const upsertMock = vi.fn().mockResolvedValue({});
+    vi.mocked(useMyBaseline).mockReturnValue({ data: null, isLoading: false } as any);
+    vi.mocked(useUpsertBaseline).mockReturnValue({ mutateAsync: upsertMock, isPending: false } as any);
+    vi.mocked(useDeleteBaseline).mockReturnValue({ mutateAsync: vi.fn(), isPending: false } as any);
+
+    renderWithClient(<BaselineSection />);
+    await userEvent.click(screen.getByRole('button', { name: /add initial snapshot/i }));
+
+    const totalHours = screen.getByLabelText(/total hours/i);
+    await userEvent.clear(totalHours);
+    await userEvent.type(totalHours, '74');
+
+    const picHours = screen.getByLabelText(/pic hours/i);
+    await userEvent.clear(picHours);
+    await userEvent.type(picHours, '74');
+
+    const landingsDay = screen.getByLabelText(/day landings/i);
+    await userEvent.clear(landingsDay);
+    await userEvent.type(landingsDay, '245');
+
+    await userEvent.click(screen.getByRole('button', { name: /save snapshot/i }));
+
+    // jsdom doesn't always trigger requestSubmit from submit-button clicks; fall
+    // back to firing the form's submit event explicitly if the click didn't.
+    if (upsertMock.mock.calls.length === 0) {
+      const form = totalHours.closest('form')!;
+      fireEvent.submit(form);
+    }
+
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    const arg = upsertMock.mock.calls[0][0];
+    expect(arg.totalMinutes).toBe(74 * 60);
+    expect(arg.picMinutes).toBe(74 * 60);
+    expect(arg.landingsDay).toBe(245);
+    expect(arg.baselineDate).toBeTruthy();
+  });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -391,6 +391,37 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/users/me/baseline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the user's initial hours snapshot (baseline)
+         * @description Returns the user's optional initial-hours snapshot. The snapshot represents
+         *     flying experience accumulated up to a chosen cutoff date and is added to
+         *     aggregated user-level statistics (`/users/me/statistics`) when the
+         *     requested date range covers the cutoff. Returns 404 when no snapshot exists.
+         */
+        get: operations["getMyBaseline"];
+        /**
+         * Create or replace the user's initial hours snapshot
+         * @description Upserts the authenticated user's initial-hours snapshot. All numeric fields
+         *     default to zero when omitted. The cutoff date marks the latest moment that
+         *     the baseline counts toward; logged flights on or after this date are added
+         *     on top of the baseline.
+         */
+        put: operations["putMyBaseline"];
+        post?: never;
+        /** Remove the user's initial hours snapshot */
+        delete: operations["deleteMyBaseline"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/users/me/statistics": {
         parameters: {
             query?: never;
@@ -2328,6 +2359,85 @@ export interface components {
              * @example 12000
              */
             crossCountryMinutes?: number;
+            /**
+             * @description Present when an initial-hours snapshot was added to these totals.
+             *     Frontends can use it to display a "(includes initial snapshot)" hint
+             *     and break down logged vs. carried-forward time.
+             */
+            baseline?: components["schemas"]["StatisticsBaselineContribution"];
+        };
+        /** @description Portion of the statistics totals contributed by the user's initial-hours snapshot. */
+        StatisticsBaselineContribution: {
+            /** Format: date */
+            baselineDate: string;
+            totalFlights: number;
+            totalMinutes: number;
+            picMinutes: number;
+            sicMinutes?: number;
+            dualMinutes: number;
+            dualGivenMinutes?: number;
+            multiPilotMinutes?: number;
+            nightMinutes: number;
+            ifrMinutes: number;
+            soloMinutes?: number;
+            crossCountryMinutes?: number;
+            landingsDay: number;
+            landingsNight: number;
+        };
+        /**
+         * @description Initial-hours snapshot input. Allows a user to record their pre-existing
+         *     flying experience as a single carried-forward total without entering
+         *     every historical flight. All numeric fields default to 0 when omitted.
+         */
+        FlightBaselineInput: {
+            /**
+             * Format: date
+             * @description Cutoff date the snapshot covers (inclusive).
+             */
+            baselineDate: string;
+            /** @default 0 */
+            totalFlights: number;
+            /**
+             * @description Total block time in minutes
+             * @default 0
+             */
+            totalMinutes: number;
+            /** @default 0 */
+            picMinutes: number;
+            /** @default 0 */
+            sicMinutes: number;
+            /**
+             * @description Dual instruction received in minutes
+             * @default 0
+             */
+            dualMinutes: number;
+            /** @default 0 */
+            dualGivenMinutes: number;
+            /** @default 0 */
+            multiPilotMinutes: number;
+            /** @default 0 */
+            nightMinutes: number;
+            /**
+             * @description Total IFR / instrument time in minutes
+             * @default 0
+             */
+            ifrMinutes: number;
+            /** @default 0 */
+            soloMinutes: number;
+            /** @default 0 */
+            crossCountryMinutes: number;
+            /** @default 0 */
+            landingsDay: number;
+            /** @default 0 */
+            landingsNight: number;
+            /** @description Optional free-form context (e.g. "From paper logbook 1998-2010"). */
+            notes?: string | null;
+        };
+        FlightBaseline: components["schemas"]["FlightBaselineInput"] & {
+            /** Format: date-time */
+            readonly createdAt: string;
+            /** Format: date-time */
+            readonly updatedAt: string;
         };
         Currency: {
             /**
@@ -4264,6 +4374,74 @@ export interface operations {
                 };
             };
             401: components["responses"]["Unauthorized"];
+        };
+    };
+    getMyBaseline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User's flight baseline */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FlightBaseline"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    putMyBaseline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FlightBaselineInput"];
+            };
+        };
+        responses: {
+            /** @description Baseline created or updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FlightBaseline"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    deleteMyBaseline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Baseline removed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
         };
     };
     getMyStatistics: {

--- a/src/components/profile/BaselineSection.tsx
+++ b/src/components/profile/BaselineSection.tsx
@@ -1,0 +1,358 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useDeleteBaseline,
+  useMyBaseline,
+  useUpsertBaseline,
+  type FlightBaseline,
+  type FlightBaselineInput,
+} from '../../hooks/useBaseline';
+
+// Shape used by the form. We track minutes as user-friendly hour strings (e.g.
+// "74", "74.5") and convert to integer minutes on submit. Landings are kept
+// as strings so the input can be cleared while typing.
+type FormState = {
+  baselineDate: string;
+  totalFlights: string;
+  totalHours: string;
+  picHours: string;
+  sicHours: string;
+  dualHours: string;
+  dualGivenHours: string;
+  multiPilotHours: string;
+  nightHours: string;
+  ifrHours: string;
+  soloHours: string;
+  crossCountryHours: string;
+  landingsDay: string;
+  landingsNight: string;
+  notes: string;
+};
+
+const EMPTY_FORM: FormState = {
+  baselineDate: new Date().toISOString().slice(0, 10),
+  totalFlights: '',
+  totalHours: '',
+  picHours: '',
+  sicHours: '',
+  dualHours: '',
+  dualGivenHours: '',
+  multiPilotHours: '',
+  nightHours: '',
+  ifrHours: '',
+  soloHours: '',
+  crossCountryHours: '',
+  landingsDay: '',
+  landingsNight: '',
+  notes: '',
+};
+
+function minutesToHours(min: number | undefined): string {
+  if (!min) return '';
+  // Show one decimal when not an integer count of hours.
+  const h = min / 60;
+  return Number.isInteger(h) ? String(h) : h.toFixed(2).replace(/\.?0+$/, '');
+}
+
+function hoursToMinutes(value: string): number {
+  if (!value.trim()) return 0;
+  const n = Number(value.replace(',', '.'));
+  if (!Number.isFinite(n) || n < 0) return 0;
+  return Math.round(n * 60);
+}
+
+function intOrZero(value: string): number {
+  if (!value.trim()) return 0;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+function baselineToForm(b: FlightBaseline): FormState {
+  return {
+    baselineDate: typeof b.baselineDate === 'string' ? b.baselineDate : EMPTY_FORM.baselineDate,
+    totalFlights: b.totalFlights ? String(b.totalFlights) : '',
+    totalHours: minutesToHours(b.totalMinutes),
+    picHours: minutesToHours(b.picMinutes),
+    sicHours: minutesToHours(b.sicMinutes),
+    dualHours: minutesToHours(b.dualMinutes),
+    dualGivenHours: minutesToHours(b.dualGivenMinutes),
+    multiPilotHours: minutesToHours(b.multiPilotMinutes),
+    nightHours: minutesToHours(b.nightMinutes),
+    ifrHours: minutesToHours(b.ifrMinutes),
+    soloHours: minutesToHours(b.soloMinutes),
+    crossCountryHours: minutesToHours(b.crossCountryMinutes),
+    landingsDay: b.landingsDay ? String(b.landingsDay) : '',
+    landingsNight: b.landingsNight ? String(b.landingsNight) : '',
+    notes: b.notes ?? '',
+  };
+}
+
+function formToInput(form: FormState): FlightBaselineInput {
+  return {
+    baselineDate: form.baselineDate,
+    totalFlights: intOrZero(form.totalFlights),
+    totalMinutes: hoursToMinutes(form.totalHours),
+    picMinutes: hoursToMinutes(form.picHours),
+    sicMinutes: hoursToMinutes(form.sicHours),
+    dualMinutes: hoursToMinutes(form.dualHours),
+    dualGivenMinutes: hoursToMinutes(form.dualGivenHours),
+    multiPilotMinutes: hoursToMinutes(form.multiPilotHours),
+    nightMinutes: hoursToMinutes(form.nightHours),
+    ifrMinutes: hoursToMinutes(form.ifrHours),
+    soloMinutes: hoursToMinutes(form.soloHours),
+    crossCountryMinutes: hoursToMinutes(form.crossCountryHours),
+    landingsDay: intOrZero(form.landingsDay),
+    landingsNight: intOrZero(form.landingsNight),
+    notes: form.notes.trim() ? form.notes.trim() : null,
+  };
+}
+
+export function BaselineSection() {
+  const { t } = useTranslation('settings');
+  const { data: baseline, isLoading } = useMyBaseline();
+  const upsert = useUpsertBaseline();
+  const remove = useDeleteBaseline();
+
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [showForm, setShowForm] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [message, setMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
+
+  // Sync form with server state when the snapshot changes.
+  useEffect(() => {
+    if (baseline) {
+      setForm(baselineToForm(baseline));
+    }
+  }, [baseline]);
+
+  const hasBaseline = Boolean(baseline);
+  const headerSummary = useMemo(() => {
+    if (!baseline) return null;
+    const hours = ((baseline.totalMinutes ?? 0) / 60).toFixed(1);
+    const pic = ((baseline.picMinutes ?? 0) / 60).toFixed(1);
+    return t('baseline.summary', {
+      hours,
+      pic,
+      landings: (baseline.landingsDay ?? 0) + (baseline.landingsNight ?? 0),
+      date: baseline.baselineDate,
+    });
+  }, [baseline, t]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    try {
+      await upsert.mutateAsync(formToInput(form));
+      setMessage({ kind: 'ok', text: t('baseline.saveSuccess') });
+      setShowForm(false);
+    } catch (err) {
+      setMessage({
+        kind: 'err',
+        text: err instanceof Error ? err.message : t('baseline.saveFailed'),
+      });
+    }
+  };
+
+  const handleDelete = async () => {
+    setMessage(null);
+    try {
+      await remove.mutateAsync();
+      setForm(EMPTY_FORM);
+      setShowForm(false);
+      setShowDeleteConfirm(false);
+      setMessage({ kind: 'ok', text: t('baseline.deleteSuccess') });
+    } catch (err) {
+      setMessage({
+        kind: 'err',
+        text: err instanceof Error ? err.message : t('baseline.deleteFailed'),
+      });
+    }
+  };
+
+  return (
+    <div className="card" data-testid="baseline-section">
+      <h2 className="section-title mb-2">{t('baseline.title')}</h2>
+      <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
+        {t('baseline.description')}
+      </p>
+
+      {isLoading ? (
+        <p className="text-sm text-slate-500">{t('baseline.loading')}</p>
+      ) : (
+        <>
+          {hasBaseline && !showForm && (
+            <div className="space-y-3">
+              <p className="text-sm text-slate-700 dark:text-slate-200">{headerSummary}</p>
+              <div className="flex gap-3">
+                <button type="button" onClick={() => setShowForm(true)} className="btn-secondary">
+                  {t('baseline.edit')}
+                </button>
+                {!showDeleteConfirm ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowDeleteConfirm(true)}
+                    className="btn-secondary text-red-700 dark:text-red-400 border-red-300 dark:border-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+                  >
+                    {t('baseline.delete')}
+                  </button>
+                ) : null}
+              </div>
+              {showDeleteConfirm && (
+                <div className="space-y-2 p-3 bg-red-50 dark:bg-red-900/20 rounded-md border border-red-200 dark:border-red-800">
+                  <p className="text-sm text-red-800 dark:text-red-300">{t('baseline.deleteConfirm')}</p>
+                  <div className="flex gap-3">
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      disabled={remove.isPending}
+                      className="btn-danger"
+                    >
+                      {remove.isPending ? t('common:deleting') : t('baseline.deleteButton')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowDeleteConfirm(false)}
+                      className="btn-secondary text-sm"
+                    >
+                      {t('common:cancel')}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {!hasBaseline && !showForm && (
+            <button type="button" onClick={() => setShowForm(true)} className="btn-primary">
+              {t('baseline.create')}
+            </button>
+          )}
+
+          {showForm && (
+            <form onSubmit={handleSubmit} className="space-y-4 mt-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <Field label={t('baseline.fields.baselineDate')} required>
+                  <input
+                    type="date"
+                    required
+                    value={form.baselineDate}
+                    onChange={(e) => setForm((s) => ({ ...s, baselineDate: e.target.value }))}
+                    className="input"
+                  />
+                </Field>
+                <Field label={t('baseline.fields.totalFlights')}>
+                  <NumberInput value={form.totalFlights} onChange={(v) => setForm((s) => ({ ...s, totalFlights: v }))} integer />
+                </Field>
+              </div>
+
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                <HoursField label={t('baseline.fields.totalHours')} value={form.totalHours} onChange={(v) => setForm((s) => ({ ...s, totalHours: v }))} />
+                <HoursField label={t('baseline.fields.picHours')} value={form.picHours} onChange={(v) => setForm((s) => ({ ...s, picHours: v }))} />
+                <HoursField label={t('baseline.fields.sicHours')} value={form.sicHours} onChange={(v) => setForm((s) => ({ ...s, sicHours: v }))} />
+                <HoursField label={t('baseline.fields.dualHours')} value={form.dualHours} onChange={(v) => setForm((s) => ({ ...s, dualHours: v }))} />
+                <HoursField label={t('baseline.fields.dualGivenHours')} value={form.dualGivenHours} onChange={(v) => setForm((s) => ({ ...s, dualGivenHours: v }))} />
+                <HoursField label={t('baseline.fields.multiPilotHours')} value={form.multiPilotHours} onChange={(v) => setForm((s) => ({ ...s, multiPilotHours: v }))} />
+                <HoursField label={t('baseline.fields.soloHours')} value={form.soloHours} onChange={(v) => setForm((s) => ({ ...s, soloHours: v }))} />
+                <HoursField label={t('baseline.fields.crossCountryHours')} value={form.crossCountryHours} onChange={(v) => setForm((s) => ({ ...s, crossCountryHours: v }))} />
+                <HoursField label={t('baseline.fields.nightHours')} value={form.nightHours} onChange={(v) => setForm((s) => ({ ...s, nightHours: v }))} />
+                <HoursField label={t('baseline.fields.ifrHours')} value={form.ifrHours} onChange={(v) => setForm((s) => ({ ...s, ifrHours: v }))} />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <Field label={t('baseline.fields.landingsDay')}>
+                  <NumberInput value={form.landingsDay} onChange={(v) => setForm((s) => ({ ...s, landingsDay: v }))} integer />
+                </Field>
+                <Field label={t('baseline.fields.landingsNight')}>
+                  <NumberInput value={form.landingsNight} onChange={(v) => setForm((s) => ({ ...s, landingsNight: v }))} integer />
+                </Field>
+              </div>
+
+              <Field label={t('baseline.fields.notes')}>
+                <textarea
+                  rows={2}
+                  maxLength={1000}
+                  value={form.notes}
+                  onChange={(e) => setForm((s) => ({ ...s, notes: e.target.value }))}
+                  className="input"
+                  placeholder={t('baseline.fields.notesPlaceholder') ?? ''}
+                />
+              </Field>
+
+              <div className="flex gap-3">
+                <button type="submit" disabled={upsert.isPending} className="btn-primary">
+                  {upsert.isPending ? t('common:saving') : t('baseline.save')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowForm(false);
+                    setMessage(null);
+                    if (baseline) setForm(baselineToForm(baseline));
+                  }}
+                  className="btn-secondary"
+                >
+                  {t('common:cancel')}
+                </button>
+              </div>
+            </form>
+          )}
+
+          {message && (
+            <p
+              className={`text-sm mt-3 ${
+                message.kind === 'ok' ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'
+              }`}
+              role="status"
+            >
+              {message.text}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, required, children }: { label: string; required?: boolean; children: React.ReactNode }) {
+  return (
+    <label className="block text-sm">
+      <span className="block mb-1 text-slate-700 dark:text-slate-300">
+        {label}
+        {required && <span className="text-red-500"> *</span>}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+function HoursField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <Field label={label}>
+      <NumberInput value={value} onChange={onChange} step="0.1" />
+    </Field>
+  );
+}
+
+function NumberInput({
+  value,
+  onChange,
+  integer,
+  step,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  integer?: boolean;
+  step?: string;
+}) {
+  return (
+    <input
+      type="number"
+      inputMode={integer ? 'numeric' : 'decimal'}
+      min={0}
+      step={integer ? 1 : step ?? '0.1'}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="input"
+    />
+  );
+}

--- a/src/components/profile/BaselineSection.tsx
+++ b/src/components/profile/BaselineSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useDeleteBaseline,
@@ -118,14 +118,12 @@ export function BaselineSection() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [message, setMessage] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null);
 
-  // Sync form with server state when the snapshot changes.
-  useEffect(() => {
-    if (baseline) {
-      setForm(baselineToForm(baseline));
-    }
-  }, [baseline]);
-
   const hasBaseline = Boolean(baseline);
+
+  const openEditor = () => {
+    setForm(baseline ? baselineToForm(baseline) : EMPTY_FORM);
+    setShowForm(true);
+  };
   const headerSummary = useMemo(() => {
     if (!baseline) return null;
     const hours = ((baseline.totalMinutes ?? 0) / 60).toFixed(1);
@@ -184,7 +182,7 @@ export function BaselineSection() {
             <div className="space-y-3">
               <p className="text-sm text-slate-700 dark:text-slate-200">{headerSummary}</p>
               <div className="flex gap-3">
-                <button type="button" onClick={() => setShowForm(true)} className="btn-secondary">
+                <button type="button" onClick={openEditor} className="btn-secondary">
                   {t('baseline.edit')}
                 </button>
                 {!showDeleteConfirm ? (
@@ -223,7 +221,7 @@ export function BaselineSection() {
           )}
 
           {!hasBaseline && !showForm && (
-            <button type="button" onClick={() => setShowForm(true)} className="btn-primary">
+            <button type="button" onClick={openEditor} className="btn-primary">
               {t('baseline.create')}
             </button>
           )}

--- a/src/hooks/useBaseline.ts
+++ b/src/hooks/useBaseline.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { apiClient } from '../api/client';
+import type { components } from '../api/schema';
+
+export type FlightBaseline = components['schemas']['FlightBaseline'];
+export type FlightBaselineInput = components['schemas']['FlightBaselineInput'];
+
+const BASELINE_QUERY_KEY = ['my-baseline'] as const;
+
+// Fetch the current user's initial-hours snapshot. Resolves to `null` when no
+// snapshot is configured (the backend returns 404).
+export const useMyBaseline = () => {
+  return useQuery({
+    queryKey: BASELINE_QUERY_KEY,
+    queryFn: async (): Promise<FlightBaseline | null> => {
+      const { data, error, response } = await apiClient.GET('/users/me/baseline');
+      if (response.status === 404) return null;
+      if (error) throw error;
+      return (data as FlightBaseline) ?? null;
+    },
+    // Snapshots change rarely; cache for the session.
+    staleTime: 5 * 60 * 1000,
+  });
+};
+
+// Create or replace the baseline.
+export const useUpsertBaseline = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: FlightBaselineInput): Promise<FlightBaseline> => {
+      const { data, error } = await apiClient.PUT('/users/me/baseline', {
+        body: input,
+      });
+      if (error) throw error;
+      return data as FlightBaseline;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: BASELINE_QUERY_KEY });
+      // Statistics now include / exclude the baseline contribution.
+      queryClient.invalidateQueries({ queryKey: ['my-statistics'] });
+    },
+  });
+};
+
+// Remove the baseline.
+export const useDeleteBaseline = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      const { error } = await apiClient.DELETE('/users/me/baseline');
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: BASELINE_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: ['my-statistics'] });
+    },
+  });
+};

--- a/src/i18n/locales/de/dashboard.json
+++ b/src/i18n/locales/de/dashboard.json
@@ -19,6 +19,7 @@
     "night": "Nacht"
   },
   "blockTimeBreakdown": "Blockzeit-Aufteilung",
+  "baselineApplied": "Inklusive {{hours}}h aus deinem Anfangsbestand (Stand {{date}}).",
   "breakdownLabels": {
     "pic": "PIC",
     "dual": "Dual",

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -166,5 +166,39 @@
     "labelPlaceholder": "z.B. iPhone 15 — Face ID",
     "registerFailed": "Passkey konnte nicht registriert werden. Bitte erneut versuchen.",
     "deleteFailed": "Passkey konnte nicht entfernt werden. Bitte erneut versuchen."
+  },
+  "baseline": {
+    "title": "Anfangsbestand",
+    "description": "Erfasse einmalig deinen vorherigen Flugerfahrungsstand, ohne jeden Altflug einzeln einzutragen. Alle erfassten oder importierten Flüge werden auf diesen Bestand aufaddiert.",
+    "loading": "Bestand wird geladen…",
+    "summary": "{{hours}}h gesamt · {{pic}}h PIC · {{landings}} Landungen, Stand {{date}}.",
+    "create": "Anfangsbestand anlegen",
+    "edit": "Bestand bearbeiten",
+    "delete": "Bestand löschen",
+    "deleteButton": "Bestand endgültig löschen",
+    "deleteConfirm": "Anfangsbestand wirklich entfernen? Erfasste Flüge bleiben unverändert.",
+    "save": "Bestand speichern",
+    "saveSuccess": "Bestand gespeichert.",
+    "saveFailed": "Bestand konnte nicht gespeichert werden.",
+    "deleteSuccess": "Bestand entfernt.",
+    "deleteFailed": "Bestand konnte nicht entfernt werden.",
+    "fields": {
+      "baselineDate": "Stichtag",
+      "totalFlights": "Anzahl Flüge",
+      "totalHours": "Gesamtstunden",
+      "picHours": "PIC-Stunden",
+      "sicHours": "Co-Pilot-Stunden",
+      "dualHours": "Dual (erhalten)",
+      "dualGivenHours": "Dual (erteilt)",
+      "multiPilotHours": "Multi-Pilot-Stunden",
+      "soloHours": "Solo-Stunden",
+      "crossCountryHours": "Überlandstunden",
+      "nightHours": "Nachtstunden",
+      "ifrHours": "IFR-/Instrumentenstunden",
+      "landingsDay": "Landungen Tag",
+      "landingsNight": "Landungen Nacht",
+      "notes": "Notizen",
+      "notesPlaceholder": "z.B. aus Papierlogbuch 1998–2010"
+    }
   }
 }

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -19,6 +19,7 @@
     "night": "night"
   },
   "blockTimeBreakdown": "Block Time Breakdown",
+  "baselineApplied": "Includes {{hours}}h carried forward from your initial-hours snapshot (as of {{date}}).",
   "breakdownLabels": {
     "pic": "PIC",
     "dual": "Dual",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -166,5 +166,39 @@
     "labelPlaceholder": "e.g. iPhone 15 — Face ID",
     "registerFailed": "Could not register passkey. Please try again.",
     "deleteFailed": "Could not revoke passkey. Please try again."
+  },
+  "baseline": {
+    "title": "Initial Hours Snapshot",
+    "description": "Record a one-time starting point of pre-existing flying experience without entering every historical flight. All logged or imported flights add on top of this snapshot.",
+    "loading": "Loading snapshot…",
+    "summary": "{{hours}}h total · {{pic}}h PIC · {{landings}} landings, as of {{date}}.",
+    "create": "Add Initial Snapshot",
+    "edit": "Edit Snapshot",
+    "delete": "Delete Snapshot",
+    "deleteButton": "Permanently Delete Snapshot",
+    "deleteConfirm": "Remove the initial-hours snapshot? Logged flights are not affected.",
+    "save": "Save Snapshot",
+    "saveSuccess": "Snapshot saved.",
+    "saveFailed": "Failed to save snapshot.",
+    "deleteSuccess": "Snapshot removed.",
+    "deleteFailed": "Failed to remove snapshot.",
+    "fields": {
+      "baselineDate": "Cutoff date",
+      "totalFlights": "Total flights",
+      "totalHours": "Total hours",
+      "picHours": "PIC hours",
+      "sicHours": "SIC hours",
+      "dualHours": "Dual received",
+      "dualGivenHours": "Dual given",
+      "multiPilotHours": "Multi-pilot hours",
+      "soloHours": "Solo hours",
+      "crossCountryHours": "Cross-country hours",
+      "nightHours": "Night hours",
+      "ifrHours": "IFR / instrument hours",
+      "landingsDay": "Day landings",
+      "landingsNight": "Night landings",
+      "notes": "Notes",
+      "notesPlaceholder": "e.g. From paper logbook 1998-2010"
+    }
   }
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -110,6 +110,18 @@ export default function DashboardPage() {
         );
       })()}
 
+      {/* Initial-hours snapshot indicator */}
+      {statistics?.baseline && (
+        <div className="mb-4 p-3 rounded-md bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800 text-sm text-blue-900 dark:text-blue-200">
+          {t('dashboard:baselineApplied', {
+            hours: ((statistics.baseline.totalMinutes ?? 0) / 60).toFixed(1),
+            date: statistics.baseline.baselineDate,
+            defaultValue:
+              'Includes {{hours}}h carried forward from your initial-hours snapshot (as of {{date}}).',
+          })}
+        </div>
+      )}
+
       {/* Stats grid */}
       <div className="grid gap-4 grid-cols-2 lg:grid-cols-4 mb-6">
         <StatCard

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -12,6 +12,7 @@ import { extractApiError, extractApiStatus } from '../lib/errors';
 import { NotificationHistory } from '../components/NotificationHistory';
 import { LanguageSwitcher } from '../components/LanguageSwitcher';
 import { PasskeySection } from '../components/auth/PasskeySection';
+import { BaselineSection } from '../components/profile/BaselineSection';
 
 export default function ProfilePage() {
   const { t } = useTranslation('settings');
@@ -481,6 +482,9 @@ export default function ProfilePage() {
       {/* ════════════════════════════════════════════════════════════════ */}
       {activeTab === 'data' && (
         <div className="space-y-6">
+          {/* Initial Hours Snapshot */}
+          <BaselineSection />
+
           {/* Flight Data Maintenance */}
           <div className="card">
             <h2 className="section-title mb-4">{t('flightData.title')}</h2>


### PR DESCRIPTION
## Summary

Adds the UI for the new initial-hours baseline snapshot. A pilot can capture their pre-NinerLog totals (hours per category plus day/night landings) once, and from then on logged or imported flights add on top of those numbers instead of starting from zero.

## What's new

- **`BaselineSection`** on the profile *Data* tab:
  - Empty state with a "Add Initial Snapshot" CTA.
  - Summary banner showing total / PIC / landings / `as of` date when a baseline exists.
  - Edit form with hours-string parsing (accepts `,` or `.`) per category, integer landings, optional notes.
  - Two-step delete confirmation.
- **Hooks** `useMyBaseline`, `useUpsertBaseline`, `useDeleteBaseline` calling the new `/users/me/baseline` endpoints; both mutations invalidate the stats cache so the dashboard refreshes.
- **Dashboard banner** that appears whenever the displayed all-time totals include the carried-forward baseline hours, with the snapshot date for context.
- **Translations** added to `settings.json` and `dashboard.json` for both EN and DE.

## Tests

- New `BaselineSection.test.tsx` covering: empty state CTA, summary rendering, and form submission converting hours to minutes.
- `npx tsc --noEmit` ✅
- `npx vitest run` — 266/266 ✅
- Dockerized Playwright e2e (`bash scripts/run-all-tests.sh`) — 81 passed / 3 skipped ✅

## Companion API PR

fjaeckel/ninerlog-api#49.