### PR TITLE
fix(backups): show "not enabled" card when API returns 503

### DIFF
--- a/src/hooks/useBackups.ts
+++ b/src/hooks/useBackups.ts
@@ -26,9 +26,19 @@ export const useBackupProviders = (enabled = true) => {
 export const useBackupDestinations = () => {
   return useQuery({
     queryKey: ['backup-destinations'],
+    retry: (failureCount, err: unknown) => {
+      // Don't retry when the feature is disabled on the server (503).
+      const status = (err as { status?: number } | undefined)?.status;
+      if (status === 503) return false;
+      return failureCount < 3;
+    },
     queryFn: async (): Promise<BackupDestination[]> => {
-      const { data, error } = await apiClient.GET('/backups/destinations');
-      if (error) throw error;
+      const { data, error, response } = await apiClient.GET('/backups/destinations');
+      if (error) {
+        const wrapped = error as Record<string, unknown>;
+        wrapped.status = response?.status;
+        throw wrapped;
+      }
       return data as BackupDestination[];
     },
   });

--- a/src/pages/backups/BackupsPage.tsx
+++ b/src/pages/backups/BackupsPage.tsx
@@ -101,7 +101,9 @@ export default function BackupsPage() {
 
   if (error) {
     // 503 means feature is disabled (no BACKUP_CREDENTIALS_KEY on server)
-    const status = (error as { response?: { status?: number } } | undefined)?.response?.status;
+    const status =
+      (error as { status?: number; response?: { status?: number } } | undefined)?.status ??
+      (error as { response?: { status?: number } } | undefined)?.response?.status;
     if (status === 503) {
       return (
         <div className="card">


### PR DESCRIPTION
## Problem

On installations where the operator has not set `BACKUP_CREDENTIALS_KEY`, the API returns `503` from `/backups/destinations`, but the Profile → Cloud Backups tab still rendered the full settings UI (empty list + "Add destination" button) instead of the intended "feature disabled" message.

## Cause

`BackupsPage` was reading the HTTP status from `error.response?.status`, but openapi-fetch surfaces the parsed JSON error body directly as `error` with no nested `response` object. The status was therefore always `undefined`, so the 503 branch never fired and the page either fell through to the generic `ErrorState` or, after React Query's default retry, kept rendering the empty settings page.

## Fix

- `useBackupDestinations` now copies the HTTP status onto the thrown error and skips the default 3× retry on `503`.
- `BackupsPage` reads `error.status` (with the old `error.response?.status` kept as a fallback) and renders the existing `backups.disabled` card explaining that cloud backups are not configured on this server.

Translation keys already exist in both `en` and `de`.

## Tests

- All 269 frontend unit tests pass (`npx vitest run`).
- The existing e2e backups spec already skips itself when the API returns 503, so no e2e changes are needed.