### PR TITLE
feat(frontend): require email verification on sign-up

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { lazyWithRetry } from './lib/lazyWithRetry';
 // so a stale PWA deployment never strands the user on a blank screen).
 const LoginPage = lazyWithRetry(() => import('./pages/auth/LoginPage'));
 const RegisterPage = lazyWithRetry(() => import('./pages/auth/RegisterPage'));
+const VerifyEmailPage = lazyWithRetry(() => import('./pages/auth/VerifyEmailPage'));
 const ResetPasswordPage = lazyWithRetry(() => import('./pages/auth/ResetPasswordPage'));
 const NewPasswordPage = lazyWithRetry(() => import('./pages/auth/NewPasswordPage'));
 const DashboardPage = lazyWithRetry(() => import('./pages/DashboardPage'));
@@ -61,6 +62,7 @@ function App() {
         {/* Public routes */}
         <Route path="/login" element={!isAuthenticated ? <LoginPage /> : <Navigate to="/dashboard" />} />
         <Route path="/register" element={!isAuthenticated ? <RegisterPage /> : <Navigate to="/dashboard" />} />
+        <Route path="/verify-email" element={<VerifyEmailPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/new-password" element={<NewPasswordPage />} />
 

--- a/src/__tests__/e2e/auth.spec.ts
+++ b/src/__tests__/e2e/auth.spec.ts
@@ -38,21 +38,12 @@ test.describe('Authentication', () => {
     await expect(page).toHaveURL('/dashboard');
   });
 
-  test('should reject wrong password', async ({ page }) => {
-    // Register a fresh user inline to avoid rate limit from createTestUser
-    const email = `e2e-badpw-${Date.now()}@test.ninerlog.app`;
-    await page.goto('/register');
-    await page.locator('#name').fill('Bad PW Test');
-    await page.locator('#email').fill(email);
-    await page.locator('#password').fill('TestPassword123!');
-    await page.locator('#confirmPassword').fill('TestPassword123!');
-    await page.getByRole('button', { name: /create account/i }).click();
-    await expect(page).toHaveURL('/dashboard', { timeout: 15000 });
-    // Logout
-    await page.locator('header').getByText('Logout').click();
-    await expect(page).toHaveURL('/login');
+  test('should reject wrong password', async ({ page, request }) => {
+    // Register a fresh user via API helper so verification is handled.
+    const auth = await createTestUser(request);
+    await page.goto('/login');
     // Try wrong password
-    await page.locator('#email').fill(email);
+    await page.locator('#email').fill(auth.email);
     await page.locator('#password').fill('wrongpassword!!');
     await page.getByRole('button', { name: 'Log In' }).click();
     await expect(page.locator('[class*="bg-red"]')).toBeVisible({ timeout: 5000 });
@@ -67,5 +58,38 @@ test.describe('Authentication', () => {
     await registerAndLogin(page);
     await page.locator('header').getByText('Logout').click();
     await expect(page).toHaveURL('/login');
+  });
+});
+
+test.describe('Email Verification', () => {
+  test('register shows the check-your-email view (no auto-login)', async ({ page }) => {
+    const email = `e2e-verify-ui-${Date.now()}@test.ninerlog.app`;
+    await page.goto('/register');
+    await page.locator('#name').fill('Verify UI');
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill('TestPassword123!');
+    await page.locator('#confirmPassword').fill('TestPassword123!');
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    // The UI no longer redirects to /dashboard — it shows the
+    // "Check your email" view instead.
+    await expect(page.getByTestId('check-email-view')).toBeVisible({ timeout: 15000 });
+    await expect(page).not.toHaveURL('/dashboard');
+  });
+
+  test('login before verifying shows the email-not-verified banner', async ({ page, request }) => {
+    const email = `e2e-verify-block-${Date.now()}@test.ninerlog.app`;
+    // Register via API but skip the verification step.
+    const regRes = await request.post('/api/v1/auth/register', {
+      data: { name: 'Blocked', email, password: 'TestPassword123!' },
+    });
+    expect(regRes.ok()).toBeTruthy();
+
+    await page.goto('/login');
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill('TestPassword123!');
+    await page.getByRole('button', { name: /log in/i }).click();
+    await expect(page.getByTestId('email-not-verified-banner')).toBeVisible({ timeout: 10000 });
+    await expect(page).not.toHaveURL('/dashboard');
   });
 });

--- a/src/__tests__/e2e/helpers.ts
+++ b/src/__tests__/e2e/helpers.ts
@@ -15,6 +15,48 @@ export function uniqueEmail(): string {
 
 const TEST_PASSWORD = 'TestPassword123!';
 
+// MailPit base URL — reachable from inside the e2e network as `mailpit-test`,
+// or via localhost when developers run Playwright outside Docker. The
+// PLAYWRIGHT_MAILPIT_URL env var lets CI override this without code changes.
+const MAILPIT_URL = process.env.PLAYWRIGHT_MAILPIT_URL || 'http://mailpit-test:8025';
+
+/**
+ * Poll MailPit for an email-verification message addressed to `email` and
+ * return the verification token from the link inside.
+ */
+async function fetchVerificationToken(
+  request: import('@playwright/test').APIRequestContext,
+  email: string,
+): Promise<string> {
+  const deadline = Date.now() + 10_000;
+  let lastErr = '';
+  while (Date.now() < deadline) {
+    try {
+      const search = await request.get(
+        `${MAILPIT_URL}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
+      );
+      if (search.ok()) {
+        const data: { messages: Array<{ ID: string; Subject: string }> } = await search.json();
+        const verifyMsg = data.messages.find((m) => /confirm your email/i.test(m.Subject));
+        if (verifyMsg) {
+          const full = await request.get(`${MAILPIT_URL}/api/v1/message/${verifyMsg.ID}`);
+          if (full.ok()) {
+            const body: { HTML?: string; Text?: string } = await full.json();
+            const haystack = (body.HTML ?? '') + '\n' + (body.Text ?? '');
+            const m = haystack.match(/token=([A-Za-z0-9_\-=]+)/);
+            if (m) return m[1];
+            lastErr = 'verification email present but no token in body';
+          }
+        }
+      }
+    } catch (err) {
+      lastErr = String(err);
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Could not retrieve verification token for ${email}: ${lastErr}`);
+}
+
 /** Stored auth state after login */
 export interface AuthContext {
   email: string;
@@ -43,13 +85,23 @@ export async function createTestUser(request: import('@playwright/test').APIRequ
   if (!regRes!.ok()) {
     throw new Error(`Registration failed: ${regRes!.status()} ${await regRes!.text()}`);
   }
-  const regData = await regRes!.json();
+
+  // Email verification is required: pull the verification token from the
+  // test SMTP server (MailPit) and exchange it for an AuthResponse.
+  const token = await fetchVerificationToken(request, email);
+  const verifyRes = await request.post('/api/v1/auth/verify-email', {
+    data: { token },
+  });
+  if (!verifyRes.ok()) {
+    throw new Error(`Email verification failed: ${verifyRes.status()} ${await verifyRes.text()}`);
+  }
+  const verifyData = await verifyRes.json();
 
   return {
     email,
     password: TEST_PASSWORD,
-    accessToken: regData.accessToken,
-    userId: regData.user?.id || '',
+    accessToken: verifyData.accessToken,
+    userId: verifyData.user?.id || '',
   };
 }
 
@@ -66,7 +118,14 @@ export async function registerAndLogin(page: Page): Promise<AuthContext> {
   await page.locator('#confirmPassword').fill(TEST_PASSWORD);
   await page.getByRole('button', { name: /create account/i }).click();
 
-  // Should redirect to dashboard after successful registration
+  // After successful registration the UI now displays the
+  // "Check your email" view — login is blocked until verification.
+  await expect(page.getByTestId('check-email-view')).toBeVisible({ timeout: 15000 });
+
+  // Pull the verification token from MailPit and visit /verify-email,
+  // which auto-redirects to /dashboard on success.
+  const token = await fetchVerificationToken(page.request, email);
+  await page.goto(`/verify-email?token=${encodeURIComponent(token)}`);
   await expect(page).toHaveURL('/dashboard', { timeout: 15000 });
   // Wait for the Layout to be fully rendered (header with Logout button)
   await expect(page.locator('button', { hasText: 'Logout' })).toBeVisible({ timeout: 10000 });

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -15,9 +15,55 @@ export interface paths {
         put?: never;
         /**
          * Register a new user
-         * @description Create a new user account with email and password
+         * @description Create a new user account with email and password. A verification email is sent
+         *     to the provided address — the user must click the link in that email to confirm
+         *     their address before they can log in. No authentication tokens are returned
+         *     from this endpoint.
          */
         post: operations["registerUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/verify-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Verify email address
+         * @description Consume an email-verification token (delivered via the registration email)
+         *     and mark the user's address as verified. On success, returns a full
+         *     `AuthResponse` so the frontend can log the user in immediately.
+         */
+        post: operations["verifyEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/verify-email/resend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Resend the email-verification message
+         * @description Request a fresh verification email. Always returns 204 regardless of whether
+         *     the email exists or is already verified, to prevent user enumeration.
+         */
+        post: operations["resendVerificationEmail"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1683,6 +1729,11 @@ export interface components {
              */
             twoFactorEnabled?: boolean;
             /**
+             * @description Whether the user has confirmed their email address.
+             * @example true
+             */
+            emailVerified?: boolean;
+            /**
              * @description Whether this user is the platform admin (computed from ADMIN_EMAIL env var, not stored in DB)
              * @example false
              */
@@ -1792,6 +1843,21 @@ export interface components {
              */
             expiresIn: number;
             user: components["schemas"]["User"];
+        };
+        RegistrationResponse: {
+            /**
+             * Format: email
+             * @description Address the verification email was sent to
+             * @example pilot@example.com
+             */
+            email: string;
+            /** @example A verification email has been sent. Please check your inbox to complete registration. */
+            message: string;
+            /**
+             * @description Always true — clients should display a "check your email" message and not attempt login until verification completes.
+             * @example true
+             */
+            verificationRequired: boolean;
         };
         License: {
             /**
@@ -3830,6 +3896,13 @@ export interface components {
              * @example Validation failed
              */
             error: string;
+            /**
+             * @description Optional machine-readable error code, used by clients to distinguish
+             *     between conditions that share an HTTP status (e.g. `email_not_verified`
+             *     vs `account_disabled` for 403 on /auth/login).
+             * @example email_not_verified
+             */
+            code?: string;
             /** @description Detailed validation errors */
             details?: {
                 /** @example totalTime */
@@ -3954,13 +4027,13 @@ export interface operations {
             };
         };
         responses: {
-            /** @description User created successfully */
+            /** @description User created — verification email sent */
             201: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["AuthResponse"];
+                    "application/json": components["schemas"]["RegistrationResponse"];
                 };
             };
             400: components["responses"]["BadRequest"];
@@ -3973,6 +4046,71 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+        };
+    };
+    verifyEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Verification token from the email link */
+                    token: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Email verified — user is now logged in */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthResponse"];
+                };
+            };
+            /** @description Invalid, expired, or already-used token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    resendVerificationEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: email
+                     * @example pilot@example.com
+                     */
+                    email: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Verification email sent (if account exists and is not yet verified) */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
         };
     };
     loginUser: {
@@ -4010,6 +4148,18 @@ export interface operations {
             };
             /** @description Invalid credentials */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /**
+             * @description Account cannot be used. The error `code` distinguishes the reason:
+             *     `email_not_verified` (email confirmation pending) or `account_disabled`.
+             */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -9,23 +9,47 @@ type RegisterRequest = operations['registerUser']['requestBody']['content']['app
 type LoginRequest = operations['loginUser']['requestBody']['content']['application/json'];
 
 type AuthResponse = components['schemas']['AuthResponse'];
+type RegistrationResponse = components['schemas']['RegistrationResponse'];
 
 export const useRegister = () => {
+  return useMutation({
+    mutationFn: async (requestData: RegisterRequest): Promise<NonNullable<RegistrationResponse>> => {
+      const { data, error } = await apiClient.POST('/auth/register', {
+        body: requestData as any,
+      });
+      if (error) throw error;
+      return data as NonNullable<RegistrationResponse>;
+    },
+  });
+};
+
+export const useVerifyEmail = () => {
   const { setAuth } = useAuthStore();
 
   return useMutation({
-    mutationFn: async (requestData: RegisterRequest): Promise<NonNullable<AuthResponse>> => {
-      const { data, error } = await apiClient.POST('/auth/register', {
-        body: requestData as any,
+    mutationFn: async (token: string): Promise<NonNullable<AuthResponse>> => {
+      const { data, error } = await apiClient.POST('/auth/verify-email', {
+        body: { token } as any,
       });
       if (error) throw error;
       return data as NonNullable<AuthResponse>;
     },
     onSuccess: (data) => {
       setAuth(data.user, data.accessToken, data.refreshToken, data.expiresIn);
-      if (data.user.preferredLocale && data.user.preferredLocale !== i18n.language) {
+      if (data.user?.preferredLocale && data.user.preferredLocale !== i18n.language) {
         i18n.changeLanguage(data.user.preferredLocale);
       }
+    },
+  });
+};
+
+export const useResendVerification = () => {
+  return useMutation({
+    mutationFn: async (email: string) => {
+      const { error } = await apiClient.POST('/auth/verify-email/resend', {
+        body: { email } as any,
+      });
+      if (error) throw error;
     },
   });
 };

--- a/src/i18n/locales/de/auth.json
+++ b/src/i18n/locales/de/auth.json
@@ -18,7 +18,11 @@
     "or": "oder",
     "signInWithPasskey": "Mit Passkey anmelden",
     "passkeySigningIn": "Warten auf Passkey…",
-    "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen. Bitte erneut versuchen."
+    "passkeyFailed": "Passkey-Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
+    "emailNotVerified": {
+      "message": "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie sich anmelden. Wir haben Ihnen einen Bestätigungslink gesendet.",
+      "resend": "Bestätigungs-E-Mail erneut senden"
+    }
   },
   "register": {
     "tagline": "Konto erstellen",
@@ -37,7 +41,13 @@
     "nameMaxLength": "Name darf maximal 255 Zeichen lang sein",
     "invalidEmail": "Ungültige E-Mail-Adresse",
     "passwordMinLength": "Passwort muss mindestens 12 Zeichen lang sein",
-    "passwordsNoMatch": "Passwörter stimmen nicht überein"
+    "passwordsNoMatch": "Passwörter stimmen nicht überein",
+    "checkYourEmail": {
+      "title": "E-Mail prüfen",
+      "description": "Wir haben einen Bestätigungslink an {{email}} gesendet. Klicken Sie auf den Link, um Ihr Konto zu aktivieren.",
+      "resend": "Bestätigungs-E-Mail erneut senden",
+      "resent": "Falls die Adresse registriert ist, haben wir gerade eine weitere Bestätigungs-E-Mail gesendet."
+    }
   },
   "resetPassword": {
     "title": "Passwort zurücksetzen",
@@ -74,5 +84,11 @@
     "verify": "Überprüfen",
     "backToLogin": "← Zurück zur Anmeldung",
     "invalidCode": "Ungültiger 2FA-Code. Versuchen Sie es erneut."
+  },
+  "verifyEmail": {
+    "verifying": "E-Mail wird bestätigt…",
+    "success": "E-Mail bestätigt!",
+    "redirecting": "Sie werden zum Dashboard weitergeleitet…",
+    "invalidOrExpired": "Dieser Bestätigungslink ist ungültig oder abgelaufen."
   }
 }

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -18,7 +18,11 @@
     "or": "or",
     "signInWithPasskey": "Sign in with passkey",
     "passkeySigningIn": "Waiting for passkey…",
-    "passkeyFailed": "Passkey sign-in failed. Please try again."
+    "passkeyFailed": "Passkey sign-in failed. Please try again.",
+    "emailNotVerified": {
+      "message": "Please confirm your email address before logging in. We sent a verification link to your inbox.",
+      "resend": "Resend verification email"
+    }
   },
   "register": {
     "tagline": "Create your account",
@@ -37,7 +41,13 @@
     "nameMaxLength": "Name must be less than 255 characters",
     "invalidEmail": "Invalid email address",
     "passwordMinLength": "Password must be at least 12 characters",
-    "passwordsNoMatch": "Passwords do not match"
+    "passwordsNoMatch": "Passwords do not match",
+    "checkYourEmail": {
+      "title": "Check your email",
+      "description": "We sent a verification link to {{email}}. Click the link in that email to activate your account.",
+      "resend": "Resend verification email",
+      "resent": "If the address is registered, we just sent another verification email."
+    }
   },
   "resetPassword": {
     "title": "Reset Password",
@@ -74,5 +84,11 @@
     "verify": "Verify",
     "backToLogin": "← Back to login",
     "invalidCode": "Invalid 2FA code. Try again."
+  },
+  "verifyEmail": {
+    "verifying": "Verifying your email…",
+    "success": "Email verified!",
+    "redirecting": "Taking you to your dashboard…",
+    "invalidOrExpired": "This verification link is invalid or has expired."
   }
 }

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useTranslation } from 'react-i18next';
-import { useLogin } from '../../hooks/useAuth';
+import { useLogin, useResendVerification } from '../../hooks/useAuth';
 import { useLogin2FA } from '../../hooks/useTwoFactor';
 import { useLoginWithPasskey, passkeysSupported } from '../../hooks/usePasskeys';
 import { useAuthStore } from '../../stores/authStore';
@@ -33,6 +33,9 @@ export default function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [twoFactorToken, setTwoFactorToken] = useState<string | null>(null);
   const [twoFACode, setTwoFACode] = useState('');
+  const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+  const [resentNotice, setResentNotice] = useState(false);
+  const resendVerification = useResendVerification();
 
   const {
     register,
@@ -45,6 +48,8 @@ export default function LoginPage() {
   const onSubmit = async (data: LoginFormData) => {
     try {
       setError(null);
+      setUnverifiedEmail(null);
+      setResentNotice(false);
       const result = await login.mutateAsync(data);
 
       // Check if 2FA is required
@@ -55,6 +60,11 @@ export default function LoginPage() {
 
       navigate('/dashboard');
     } catch (err: any) {
+      const code = err?.code ?? err?.response?.data?.code;
+      if (code === 'email_not_verified') {
+        setUnverifiedEmail(data.email);
+        return;
+      }
       const msg = err?.error || err?.message || err?.response?.data?.error || '';
       if (msg.toLowerCase().includes('too many requests')) {
         setError(t('auth:login.rateLimited'));
@@ -66,6 +76,16 @@ export default function LoginPage() {
         setError(msg || t('auth:login.invalidCredentials'));
       }
     }
+  };
+
+  const handleResendVerification = async () => {
+    if (!unverifiedEmail) return;
+    try {
+      await resendVerification.mutateAsync(unverifiedEmail);
+    } catch {
+      // ignore — endpoint always 204
+    }
+    setResentNotice(true);
   };
 
   const handleTwoFactorSubmit = async () => {
@@ -211,6 +231,27 @@ export default function LoginPage() {
           {error && (
             <div className="bg-red-50 border border-red-200 text-red-700 dark:bg-red-900/20 dark:border-red-800 dark:text-red-400 px-4 py-3 rounded-lg text-sm">
               {error}
+            </div>
+          )}
+
+          {unverifiedEmail && (
+            <div
+              className="bg-amber-50 border border-amber-200 text-amber-800 dark:bg-amber-900/20 dark:border-amber-800 dark:text-amber-300 px-4 py-3 rounded-lg text-sm space-y-2"
+              data-testid="email-not-verified-banner"
+            >
+              <p>{t('auth:login.emailNotVerified.message')}</p>
+              {resentNotice ? (
+                <p className="font-medium">{t('auth:register.checkYourEmail.resent')}</p>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleResendVerification}
+                  disabled={resendVerification.isPending}
+                  className="font-medium underline hover:no-underline"
+                >
+                  {t('auth:login.emailNotVerified.resend')}
+                </button>
+              )}
             </div>
           )}
 

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { useRegister } from '../../hooks/useAuth';
+import { useRegister, useResendVerification } from '../../hooks/useAuth';
 import { APP_NAME } from '../../lib/config';
 import { LogoMark } from '../../components/ui/Logo';
 import { extractApiError, extractApiStatus } from '../../lib/errors';
@@ -25,9 +25,11 @@ type RegisterFormData = z.infer<typeof registerSchema>;
 
 export default function RegisterPage() {
   const { t } = useTranslation('auth');
-  const navigate = useNavigate();
   const registerMutation = useRegister();
+  const resendMutation = useResendVerification();
   const [error, setError] = useState<string | null>(null);
+  const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
+  const [resentNotice, setResentNotice] = useState(false);
 
   const {
     register,
@@ -45,7 +47,7 @@ export default function RegisterPage() {
         password: data.password,
         name: data.name,
       });
-      navigate('/dashboard');
+      setRegisteredEmail(data.email);
     } catch (err: unknown) {
       const status = extractApiStatus(err);
       if (status === 409) {
@@ -53,6 +55,17 @@ export default function RegisterPage() {
       } else {
         setError(extractApiError(err, t('auth:register.registrationFailed')));
       }
+    }
+  };
+
+  const handleResend = async () => {
+    if (!registeredEmail) return;
+    try {
+      await resendMutation.mutateAsync(registeredEmail);
+      setResentNotice(true);
+    } catch {
+      // Endpoint always returns 204 — but be safe.
+      setResentNotice(true);
     }
   };
 
@@ -78,7 +91,38 @@ export default function RegisterPage() {
           </p>
         </div>
 
-        <form
+        {registeredEmail ? (
+          <div className="card p-6 space-y-4" data-testid="check-email-view">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {t('auth:register.checkYourEmail.title')}
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {t('auth:register.checkYourEmail.description', { email: registeredEmail })}
+            </p>
+            {resentNotice && (
+              <div className="bg-green-50 border border-green-200 text-green-700 dark:bg-green-900/20 dark:border-green-800 dark:text-green-400 px-4 py-3 rounded-lg text-sm">
+                {t('auth:register.checkYourEmail.resent')}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={resendMutation.isPending}
+              className="btn-secondary w-full"
+            >
+              {t('auth:register.checkYourEmail.resend')}
+            </button>
+            <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+              <Link
+                to="/login"
+                className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                {t('auth:register.logIn')}
+              </Link>
+            </p>
+          </div>
+        ) : (
+          <form
           className="card p-6 space-y-5"
           onSubmit={handleSubmit(onSubmit)}
         >
@@ -171,6 +215,7 @@ export default function RegisterPage() {
             </Link>
           </p>
         </form>
+        )}
       </div>
     </div>
   );

--- a/src/pages/auth/VerifyEmailPage.tsx
+++ b/src/pages/auth/VerifyEmailPage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useVerifyEmail } from '../../hooks/useAuth';
+import { APP_NAME } from '../../lib/config';
+import { LogoMark } from '../../components/ui/Logo';
+
+type Status = 'verifying' | 'success' | 'invalid';
+
+export default function VerifyEmailPage() {
+  const { t } = useTranslation('auth');
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const verifyMutation = useVerifyEmail();
+  const [status, setStatus] = useState<Status>('verifying');
+  const ranRef = useRef(false);
+
+  const token = params.get('token') ?? '';
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    ranRef.current = true;
+
+    if (!token) {
+      setStatus('invalid');
+      return;
+    }
+
+    verifyMutation
+      .mutateAsync(token)
+      .then(() => {
+        setStatus('success');
+        setTimeout(() => navigate('/dashboard'), 1200);
+      })
+      .catch(() => {
+        setStatus('invalid');
+      });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
+  return (
+    <div className="relative min-h-screen flex items-center justify-center overflow-hidden bg-slate-50 dark:bg-slate-900 px-4 py-10">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            'radial-gradient(60rem 36rem at 50% -10%, rgba(37,99,235,0.18), transparent 60%), radial-gradient(40rem 28rem at 100% 110%, rgba(30,58,95,0.20), transparent 60%)',
+        }}
+      />
+      <div className="relative w-full max-w-[400px] space-y-6">
+        <div className="text-center">
+          <div className="inline-flex items-center justify-center mb-3">
+            <LogoMark size={64} className="drop-shadow-md" />
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-gradient-brand">{APP_NAME}</h1>
+        </div>
+
+        <div className="card p-6 space-y-4 text-center" data-testid="verify-email-card">
+          {status === 'verifying' && (
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {t('auth:verifyEmail.verifying')}
+            </p>
+          )}
+          {status === 'success' && (
+            <>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                {t('auth:verifyEmail.success')}
+              </h2>
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                {t('auth:verifyEmail.redirecting')}
+              </p>
+            </>
+          )}
+          {status === 'invalid' && (
+            <>
+              <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+                {t('auth:verifyEmail.invalidOrExpired')}
+              </h2>
+              <p className="text-center text-sm text-slate-500 dark:text-slate-400">
+                <Link
+                  to="/login"
+                  className="font-medium text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+                >
+                  {t('auth:register.logIn')}
+                </Link>
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/auth/VerifyEmailPage.tsx
+++ b/src/pages/auth/VerifyEmailPage.tsx
@@ -12,19 +12,14 @@ export default function VerifyEmailPage() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const verifyMutation = useVerifyEmail();
-  const [status, setStatus] = useState<Status>('verifying');
-  const ranRef = useRef(false);
-
   const token = params.get('token') ?? '';
+  const [status, setStatus] = useState<Status>(token ? 'verifying' : 'invalid');
+  const ranRef = useRef(false);
 
   useEffect(() => {
     if (ranRef.current) return;
+    if (!token) return;
     ranRef.current = true;
-
-    if (!token) {
-      setStatus('invalid');
-      return;
-    }
 
     verifyMutation
       .mutateAsync(token)


### PR DESCRIPTION
## Summary

Wires the new email-verification API into the frontend: registration no longer auto-logs the user in but renders a "check your email" view, and a new `/verify-email` route handles the click-through link.

## Behaviour

- `RegisterPage` shows a "Check your email" card on success with a resend button, instead of redirecting to `/dashboard`.
- `LoginPage` detects `error.code === "email_not_verified"` and renders an amber banner with a resend-link action.
- `VerifyEmailPage` (`/verify-email?token=...`) calls `useVerifyEmail`, shows verifying / success / invalid states, and auto-redirects to `/dashboard` on success.

## Implementation

Commits split into digestible chunks:

1. **API client** — regenerated from the updated OpenAPI spec; picks up `/auth/verify-email`, `/auth/verify-email/resend`, the `verificationRequired` flag, and the `email_not_verified` error code.
2. **Hooks + i18n** — adds `useVerifyEmail` and `useResendVerification`; en/de strings for the new views.
3. **UI flow** — RegisterPage check-email view, LoginPage banner, new VerifyEmailPage, lazy route in `App.tsx`.
4. **Playwright e2e** — `helpers.ts` now fetches the verification token from MailPit (`PLAYWRIGHT_MAILPIT_URL`, defaults to `mailpit-test:8025`) so existing tests keep working; adds an `Email Verification` describe block that asserts both the check-email view and the email-not-verified banner.

## Tests

- `npx tsc --noEmit` — clean
- `npx vitest run` — 269/269 pass
- `bash scripts/run-all-tests.sh` (Playwright) — 84 passed, 3 skipped (WebAuthn, unrelated)

## Related

API PR: https://github.com/fjaeckel/ninerlog-api/pull/50

Depends on the API PR being deployed before this one is merged into a shared environment, since the new endpoints are required for the UI to function.
