### PR TITLE
feat(admin): show cloud backup config status in admin panel

### DIFF
--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -3702,6 +3702,17 @@ export interface components {
             smtpConfigured: boolean;
             /** @description Whether ADMIN_EMAIL is set */
             adminEmailConfigured: boolean;
+            /** @description Whether cloud backups are enabled (BACKUP_CREDENTIALS_KEY is set) */
+            cloudBackupsConfigured: boolean;
+            /**
+             * @description Names of registered cloud backup providers (e.g. s3, sftp, webdav). Empty when cloud backups are disabled.
+             * @example [
+             *       "s3",
+             *       "sftp",
+             *       "webdav"
+             *     ]
+             */
+            cloudBackupProviders: string[];
         };
         AdminUser: {
             /** Format: uuid */

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -185,6 +185,9 @@
       "rateLimitAdmin": "Rate Limit (Admin)",
       "smtp": "SMTP",
       "adminEmail": "Admin-E-Mail",
+      "cloudBackups": "Cloud-Backups",
+      "cloudBackupProviders": "Cloud-Backup-Anbieter",
+      "cloudBackupProvidersNone": "Keine registriert",
       "configured": "Konfiguriert",
       "notConfigured": "Nicht konfiguriert"
     },

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -185,6 +185,9 @@
       "rateLimitAdmin": "Rate Limit (Admin)",
       "smtp": "SMTP",
       "adminEmail": "Admin Email",
+      "cloudBackups": "Cloud Backups",
+      "cloudBackupProviders": "Cloud Backup Providers",
+      "cloudBackupProvidersNone": "None registered",
       "configured": "Configured",
       "notConfigured": "Not configured"
     },

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -424,6 +424,18 @@ function ConfigTab() {
         ? <span className="text-green-600 dark:text-green-400 font-medium">{t('admin.config.configured')}</span>
         : <span className="text-amber-600 dark:text-amber-400 font-medium">{t('admin.config.notConfigured')}</span>,
     },
+    {
+      label: t('admin.config.cloudBackups'),
+      value: data.cloudBackupsConfigured
+        ? <span className="text-green-600 dark:text-green-400 font-medium">{t('admin.config.configured')}</span>
+        : <span className="text-amber-600 dark:text-amber-400 font-medium">{t('admin.config.notConfigured')}</span>,
+    },
+    {
+      label: t('admin.config.cloudBackupProviders'),
+      value: data.cloudBackupProviders.length > 0
+        ? <span className="font-mono text-xs uppercase">{data.cloudBackupProviders.join(', ')}</span>
+        : <span className="text-slate-400">{t('admin.config.cloudBackupProvidersNone')}</span>,
+    },
   ];
 
   return (


### PR DESCRIPTION
## Summary

Extends the Admin → Config tab with two new rows so operators can verify cloud-backup availability from the admin panel:

- **Cloud Backups**: shows *Configured* / *Not configured* based on whether the API has `BACKUP_CREDENTIALS_KEY` set and the service initialized.
- **Cloud Backup Providers**: lists the names of providers registered on the server (e.g. `S3, SFTP, WEBDAV`), or *None registered* when the feature is disabled.

## Changes

- `src/api/schema.ts`: regenerated from the updated OpenAPI spec (adds `cloudBackupsConfigured` and `cloudBackupProviders` on `AdminConfig`).
- `src/pages/admin/AdminPage.tsx`: render the two new rows in `ConfigTab`.
- `src/i18n/locales/{en,de}/common.json`: new labels under `admin.config.*`.

## Testing

- `npx vitest run` — 269/269 pass
- `bash scripts/run-all-tests.sh` (docker-based Playwright) — 84 passed, 3 skipped, 0 failed

## Companion API PR

Depends on fjaeckel/ninerlog-api#admin-cloud-backup-info for the new `AdminConfig` fields.