### PR TITLE
test(e2e): replace MinIO with SeaweedFS for S3 backup e2e backend

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -137,7 +137,7 @@ services:
       WEBAUTHN_RP_ORIGINS: "http://app.ninerlog.test:5173,http://localhost:5174,http://localhost:5173"
       # Cloud backups
       BACKUP_CREDENTIALS_KEY: "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY="
-      E2E_MINIO_ENDPOINT: "http://minio-test:9000"
+      E2E_S3_ENDPOINT: "http://seaweedfs-test:8333"
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/health"]
       interval: 10s
@@ -149,37 +149,63 @@ services:
     networks:
       - test-network
 
-  minio-test:
-    image: minio/minio:latest
-    container_name: ninerlog-frontend-test-minio
-    command: server /data --console-address ":9001"
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+  seaweedfs-test:
+    image: chrislusf/seaweedfs:latest
+    container_name: ninerlog-frontend-test-seaweedfs
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        mkdir -p /etc/seaweedfs
+        cat > /etc/seaweedfs/s3.json <<'EOF'
+        {
+          "identities": [
+            {
+              "name": "admin",
+              "credentials": [
+                { "accessKey": "ninerlogadmin", "secretKey": "ninerlogsecret" }
+              ],
+              "actions": ["Admin", "Read", "Write", "List", "Tagging"]
+            }
+          ]
+        }
+        EOF
+        exec weed server -s3 -s3.port=8333 -s3.config=/etc/seaweedfs/s3.json -dir=/data -ip=seaweedfs-test
     expose:
-      - "9000"
+      - "8333"
+      - "9333"
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/ready || exit 1"]
+      test:
+        - CMD-SHELL
+        - |
+          curl -sf http://localhost:9333/cluster/status > /dev/null \
+          && curl -s -o /dev/null -w '%{http_code}' http://localhost:8333/ | grep -qE '200|403'
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 30
     profiles:
       - e2e
     networks:
       - test-network
 
   minio-test-init:
-    image: minio/mc:latest
-    container_name: ninerlog-frontend-test-minio-init
+    # Init job that creates the e2e bucket on SeaweedFS via `weed shell`.
+    # Keeps the legacy service name so existing run scripts keep working.
+    image: chrislusf/seaweedfs:latest
+    container_name: ninerlog-frontend-test-seaweedfs-init
     depends_on:
-      minio-test:
+      seaweedfs-test:
         condition: service_healthy
-    entrypoint: >
-      /bin/sh -c "
-        mc alias set local http://minio-test:9000 minioadmin minioadmin &&
-        mc mb --ignore-existing local/ninerlog-backups &&
-        exit 0
-      "
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        for i in $$(seq 1 30); do
+          echo "s3.bucket.create -name ninerlog-backups" | weed shell -master seaweedfs-test:9333 && exit 0
+          sleep 1
+        done
+        echo "failed to create bucket" >&2
+        exit 1
     profiles:
       - e2e
     networks:

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -28,8 +28,8 @@ else
     echo "=================================================="
     echo ""
     
-    echo "🐳 Starting test environment (DB + MailPit + API + Frontend + MinIO)..."
-    docker compose -f docker-compose.test.yml --profile e2e up -d --build postgres-test mailpit-test minio-test api-test frontend-dev
+    echo "🐳 Starting test environment (DB + MailPit + API + Frontend + SeaweedFS)..."
+    docker compose -f docker-compose.test.yml --profile e2e up -d --build postgres-test mailpit-test seaweedfs-test api-test frontend-dev
     docker compose -f docker-compose.test.yml --profile e2e run --rm minio-test-init || true
     
     echo "⏳ Waiting for services to be healthy..."

--- a/src/__tests__/e2e/backups.spec.ts
+++ b/src/__tests__/e2e/backups.spec.ts
@@ -2,14 +2,17 @@ import { test, expect } from '@playwright/test';
 import { registerAndLogin } from './helpers';
 
 // Cloud backup settings flow. Requires the API to be running with
-// BACKUP_CREDENTIALS_KEY set and a reachable MinIO service. In the docker
-// e2e environment (docker-compose.test.yml) this is provided as
-// "minio-test:9000" and a pre-created bucket "ninerlog-backups".
+// BACKUP_CREDENTIALS_KEY set and a reachable S3-compatible service. In the
+// docker e2e environment (docker-compose.test.yml) this is provided by a
+// SeaweedFS container at "seaweedfs-test:8333" with a pre-created bucket
+// "ninerlog-backups".
 //
 // When running locally without those services, this suite is auto-skipped.
 
-const MINIO_ENDPOINT = process.env.E2E_MINIO_ENDPOINT || 'http://minio-test:9000';
-const MINIO_BUCKET = process.env.E2E_MINIO_BUCKET || 'ninerlog-backups';
+const S3_ENDPOINT = process.env.E2E_S3_ENDPOINT || 'http://seaweedfs-test:8333';
+const S3_BUCKET = process.env.E2E_S3_BUCKET || 'ninerlog-backups';
+const S3_ACCESS_KEY = process.env.E2E_S3_ACCESS_KEY || 'ninerlogadmin';
+const S3_SECRET_KEY = process.env.E2E_S3_SECRET_KEY || 'ninerlogsecret';
 
 test.describe('Cloud Backups', () => {
   test('create, test, run, view history, and delete an S3 destination', async ({ page, request }) => {
@@ -33,17 +36,17 @@ test.describe('Cloud Backups', () => {
 
     // Provider should default to S3
     await expect(page.getByLabel(/provider/i)).toBeVisible();
-    await page.getByLabel(/display name/i).fill('E2E MinIO bucket');
-    await page.getByLabel(/^Bucket/i).fill(MINIO_BUCKET);
+    await page.getByLabel(/display name/i).fill('E2E S3 bucket');
+    await page.getByLabel(/^Bucket/i).fill(S3_BUCKET);
     await page.getByLabel(/^Region/i).fill('us-east-1');
-    await page.getByLabel(/endpoint url/i).fill(MINIO_ENDPOINT);
-    await page.getByLabel(/access key id/i).fill('minioadmin');
-    await page.getByLabel(/secret access key/i).fill('minioadmin');
+    await page.getByLabel(/endpoint url/i).fill(S3_ENDPOINT);
+    await page.getByLabel(/access key id/i).fill(S3_ACCESS_KEY);
+    await page.getByLabel(/secret access key/i).fill(S3_SECRET_KEY);
 
     await page.getByRole('button', { name: /create destination/i }).click();
 
     // Card visible
-    const card = page.locator('[data-testid="backup-destination"]', { hasText: 'E2E MinIO bucket' });
+    const card = page.locator('[data-testid="backup-destination"]', { hasText: 'E2E S3 bucket' });
     await expect(card).toBeVisible({ timeout: 15000 });
 
     // Test connection


### PR DESCRIPTION
## Why

MinIO's community-edition repos have been archived. Switch the docker e2e environment to **SeaweedFS**, which provides a still-actively-maintained S3-compatible gateway.

## Changes

- **`docker-compose.test.yml`** — replace the `minio-test` service with `seaweedfs-test`.
  - S3 API on `:8333`, static admin identity via inline `s3.json` config.
  - Curl-based healthcheck against `/cluster/status` plus a HEAD on the S3 port.
  - The init service keeps its legacy `minio-test-init` name so existing run scripts keep working, but now creates the bucket via `weed shell`.
- **`src/__tests__/e2e/backups.spec.ts`** — rename env vars to `E2E_S3_*` (with backward-compatible defaults), use SeaweedFS credentials (`ninerlogadmin` / `ninerlogsecret`), and update the display-name fixture.
- **`scripts/run-all-tests.sh`** — bring up `seaweedfs-test` instead of `minio-test`.

## Paired PR

Pairs with fjaeckel/ninerlog-api#58 which swaps the same backend on the API repo's e2e suite and reorders `S3 provider.Validate()` so HEAD-only auth errors no longer get misclassified as 403.