### PR TITLE
feat(admin): show cloud backup destination counts on dashboard

### DIFF
--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -3645,6 +3645,21 @@ export interface components {
             newUsersThisWeek: number;
             lockedAccounts: number;
             disabledAccounts: number;
+            /** @description Counts of user-configured cloud backup destinations. */
+            cloudBackupDestinations: {
+                /** @description Total number of cloud backup destinations configured across all users. */
+                total: number;
+                /**
+                 * @description Number of destinations grouped by provider name (e.g. {"s3": 3, "sftp": 1}). Providers with zero destinations are omitted.
+                 * @example {
+                 *       "s3": 3,
+                 *       "sftp": 1
+                 *     }
+                 */
+                byProvider: {
+                    [key: string]: number;
+                };
+            };
         };
         Announcement: {
             /** @description Unique identifier (UUID for admin announcements, string key for hints) */

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -117,7 +117,9 @@
       "flightsThisMonth": "Flüge diesen Monat",
       "newUsersWeek": "Neue Benutzer (7T)",
       "lockedAccounts": "Gesperrte Konten",
-      "disabledAccounts": "Deaktivierte Konten"
+      "disabledAccounts": "Deaktivierte Konten",
+      "cloudBackupDestinations": "Cloud-Backup-Ziele",
+      "cloudBackupDestinationsNone": "Noch keine Cloud-Backup-Ziele von Benutzern konfiguriert."
     },
     "users": {
       "searchPlaceholder": "Nach E-Mail oder Name suchen...",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -117,7 +117,9 @@
       "flightsThisMonth": "Flights This Month",
       "newUsersWeek": "New Users (7d)",
       "lockedAccounts": "Locked Accounts",
-      "disabledAccounts": "Disabled Accounts"
+      "disabledAccounts": "Disabled Accounts",
+      "cloudBackupDestinations": "Cloud Backup Destinations",
+      "cloudBackupDestinationsNone": "No cloud backup destinations configured by users yet."
     },
     "users": {
       "searchPlaceholder": "Search by email or name...",

--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -103,14 +103,44 @@ function DashboardTab() {
     { label: t('admin.dashboard.disabledAccounts'), value: data.disabledAccounts, warn: data.disabledAccounts > 0 },
   ];
 
+  const backups = data.cloudBackupDestinations;
+  const backupProviders = backups
+    ? Object.entries(backups.byProvider).sort(([a], [b]) => a.localeCompare(b))
+    : [];
+
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
-      {stats.map((s) => (
-        <div key={s.label} className="card text-center py-4">
-          <div className={`text-2xl font-bold ${s.warn ? 'text-amber-600 dark:text-amber-400' : 'text-slate-800 dark:text-slate-100'}`}>{s.value}</div>
-          <div className="text-xs text-slate-500 mt-1">{s.label}</div>
+    <div className="space-y-6">
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        {stats.map((s) => (
+          <div key={s.label} className="card text-center py-4">
+            <div className={`text-2xl font-bold ${s.warn ? 'text-amber-600 dark:text-amber-400' : 'text-slate-800 dark:text-slate-100'}`}>{s.value}</div>
+            <div className="text-xs text-slate-500 mt-1">{s.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {backups && (
+        <div className="card p-4">
+          <div className="flex items-baseline justify-between mb-3">
+            <h3 className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {t('admin.dashboard.cloudBackupDestinations')}
+            </h3>
+            <div className="text-2xl font-bold text-slate-800 dark:text-slate-100">{backups.total}</div>
+          </div>
+          {backupProviders.length === 0 ? (
+            <div className="text-xs text-slate-500">{t('admin.dashboard.cloudBackupDestinationsNone')}</div>
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+              {backupProviders.map(([provider, count]) => (
+                <div key={provider} className="rounded border border-slate-200 dark:border-slate-700 px-3 py-2 text-center">
+                  <div className="text-lg font-semibold text-slate-800 dark:text-slate-100">{count}</div>
+                  <div className="text-xs text-slate-500 mt-0.5 uppercase tracking-wide">{provider}</div>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
-      ))}
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a **Cloud Backup Destinations** card to the admin dashboard tab, driven by the new `cloudBackupDestinations` field on `AdminStats` (see companion API PR).

The card shows:

- the **total** number of destinations configured by users across the instance, and
- a **per-provider breakdown** (e.g. `S3: 3`, `SFTP: 1`).

If no destinations are configured yet, a friendly *"No cloud backup destinations configured by users yet."* message is shown instead.

This is a follow-up to the recently merged "cloud backup config status on admin panel" PR, which surfaced *which providers are registered on the server* on the Config tab. This PR adds the corresponding **usage** stats on the Dashboard tab.

## Changes

- Regenerated API client from the updated OpenAPI spec.
- Extended `DashboardTab` in `AdminPage.tsx` to render the new card under the existing stats grid.
- Added English and German translations:
  - `admin.dashboard.cloudBackupDestinations`
  - `admin.dashboard.cloudBackupDestinationsNone`

## Tests

- Vitest: 269/269 ✅

Companion API PR: fjaeckel/ninerlog-api#feat/admin-cloud-backup-stats