### PR TITLE
feat(currency): show 'experience window opens' banner for fresh EASA ratings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15854,9 +15854,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.5",
-    "tmp": ">=0.2.4",
+    "tmp": ">=0.2.6",
     "uuid": ">=14.0.0"
   },
   "engines": {

--- a/src/__tests__/currency/CurrencyCard.test.tsx
+++ b/src/__tests__/currency/CurrencyCard.test.tsx
@@ -219,4 +219,32 @@ describe('CurrencyCard', () => {
     render(<CurrencyCard rating={baseRating} />);
     expect(screen.queryByTestId('launch-method-currency')).not.toBeInTheDocument();
   });
+
+  it('renders the window-opens banner when revalidation window is closed', () => {
+    const freshlyRevalidated: ClassRatingCurrency = {
+      classRatingId: 'cr-fresh',
+      classType: 'SEP_LAND',
+      licenseId: 'lic-1',
+      regulatoryAuthority: 'EASA',
+      licenseType: 'PPL',
+      status: 'current',
+      expiryDate: '2028-05-15',
+      windowOpensAt: '2027-05-15',
+      windowOpen: false,
+      message: 'EASA SEP_LAND — recently revalidated; experience window opens 2027-05-15',
+    };
+    render(<CurrencyCard rating={freshlyRevalidated} />);
+    expect(screen.getByTestId('currency-window-closed')).toBeInTheDocument();
+    expect(screen.queryByTestId(/requirement-/)).not.toBeInTheDocument();
+  });
+
+  it('does not render the window banner once the window is open', () => {
+    const inWindow: ClassRatingCurrency = {
+      ...baseRating,
+      windowOpensAt: '2025-06-15',
+      windowOpen: true,
+    };
+    render(<CurrencyCard rating={inWindow} />);
+    expect(screen.queryByTestId('currency-window-closed')).not.toBeInTheDocument();
+  });
 });

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -3165,6 +3165,24 @@ export interface components {
              * @description Class rating expiry date
              */
             expiryDate?: string | null;
+            /**
+             * Format: date
+             * @description For ratings whose experience window is anchored to expiry (EASA
+             *     FCL.740.A SEP/TMG/MEP/SET and FCL.625.A IR), the date on which
+             *     the 12-month experience-counting window opens (expiry − 12
+             *     months). Omitted for rolling-window rules (LAPL FCL.140.A,
+             *     SPL FCL.140.S) and for expiry-only ratings.
+             */
+            windowOpensAt?: string | null;
+            /**
+             * @description Only meaningful when `windowOpensAt` is set. True if the
+             *     revalidation experience window is currently open
+             *     (now >= windowOpensAt). When false, flight experience accrued
+             *     today does not yet count toward this rating's revalidation, so
+             *     `requirements` is omitted and `status` stays `current` until the
+             *     window opens.
+             */
+            windowOpen?: boolean;
             /** @description Human-readable status message */
             message?: string;
             /** @description Progress metrics toward currency requirements (authority-specific) */
@@ -3612,6 +3630,13 @@ export interface components {
             /** Format: uuid */
             adminUserId: string;
             /**
+             * Format: email
+             * @description Email of the admin who performed the action (if the account still exists)
+             */
+            adminEmail?: string;
+            /** @description Display name of the admin who performed the action (if the account still exists) */
+            adminName?: string;
+            /**
              * @description The admin action performed
              * @example disable_user
              */
@@ -3621,6 +3646,13 @@ export interface components {
              * @description The user affected by the action (if any)
              */
             targetUserId?: string;
+            /**
+             * Format: email
+             * @description Email of the target user (if any, and if the account still exists)
+             */
+            targetUserEmail?: string;
+            /** @description Display name of the target user (if any, and if the account still exists) */
+            targetUserName?: string;
             /** @description Additional details about the action (JSON) */
             details?: Record<string, never>;
             /** Format: date-time */

--- a/src/components/currency/CurrencyCard.tsx
+++ b/src/components/currency/CurrencyCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { ShieldCheck, ShieldAlert, ShieldX, Shield, Calendar } from 'lucide-react';
+import { ShieldCheck, ShieldAlert, ShieldX, Shield, Calendar, Clock } from 'lucide-react';
 import type { ClassRatingCurrency, CurrencyRequirement, CurrencyStatus } from '../../types/api';
 import { useFormatPrefs } from '../../hooks/useFormatPrefs';
 
@@ -120,6 +120,26 @@ export function CurrencyCard({ rating }: CurrencyCardProps) {
       <p className="text-sm text-slate-600 dark:text-slate-300 mb-3">
         {rating.message}
       </p>
+
+      {/* Window-not-yet-open banner — shown for EASA FCL.740.A / FCL.625.A
+          ratings during the first ~12 months after revalidation, when flight
+          experience does not yet count toward the next revalidation. */}
+      {rating.windowOpensAt && rating.windowOpen === false && (
+        <div
+          className="mb-3 rounded-md border border-sky-200 bg-sky-50/70 px-3 py-2 text-xs text-sky-800 dark:border-sky-800/50 dark:bg-sky-900/20 dark:text-sky-200 inline-flex items-start gap-2 w-full"
+          data-testid="currency-window-closed"
+        >
+          <Clock className="w-3.5 h-3.5 mt-0.5 shrink-0" aria-hidden="true" />
+          <div className="space-y-0.5">
+            <p className="font-medium">
+              {t('windowOpensLabel', { date: fmtDate(rating.windowOpensAt) })}
+            </p>
+            <p className="text-sky-700/80 dark:text-sky-300/80">
+              {t('windowClosedHint')}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Requirements with progress bars */}
       {rating.requirements && rating.requirements.length > 0 && (

--- a/src/i18n/locales/de/currency.json
+++ b/src/i18n/locales/de/currency.json
@@ -53,6 +53,8 @@
     "OTHER": "Sonstige"
   },
   "expiresLabel": "Gültig bis: {{date}}",
+  "windowOpensLabel": "Erfahrungs-Zeitfenster öffnet am {{date}}",
+  "windowClosedHint": "Kürzlich verlängert — Flüge vor diesem Datum zählen nicht für die nächste Verlängerung.",
   "launchesCount": "{{current}} / {{required}} Starts",
   "ruleDescriptions": {
     "easa_sep_tmg": "Erfordert 12h Gesamtflugzeit + 6h als PIC + 12 Starts & Landungen + 1h Auffrischungsschulung mit Fluglehrer innerhalb der 12 Monate vor dem Ablaufdatum der Berechtigung (EASA FCL.740.A(b)(1))",

--- a/src/i18n/locales/en/currency.json
+++ b/src/i18n/locales/en/currency.json
@@ -53,6 +53,8 @@
     "OTHER": "Other"
   },
   "expiresLabel": "Expires: {{date}}",
+  "windowOpensLabel": "Experience window opens {{date}}",
+  "windowClosedHint": "Recently revalidated — flights logged before this date don't count toward the next revalidation.",
   "launchesCount": "{{current}} / {{required}} launches",
   "ruleDescriptions": {
     "easa_sep_tmg": "Requires 12h total flight time + 6h as PIC + 12 takeoffs & landings + 1h refresher training with instructor within the 12 months preceding the expiry date of the rating (EASA FCL.740.A(b)(1))",

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -254,6 +254,18 @@ export interface ClassRatingCurrency {
   licenseType?: string;
   status: CurrencyStatus;
   expiryDate?: string | null;
+  /**
+   * For expiry-anchored revalidation rules (EASA FCL.740.A SEP/TMG/MEP/SET,
+   * FCL.625.A IR), the date on which the 12-month experience-counting window
+   * opens. Omitted for rolling-window rules (LAPL/SPL) and expiry-only ratings.
+   */
+  windowOpensAt?: string | null;
+  /**
+   * Only meaningful when `windowOpensAt` is set. False during the
+   * "recently revalidated" period — flight experience does not yet count
+   * toward this rating's revalidation and `requirements` is suppressed.
+   */
+  windowOpen?: boolean;
   message: string;
   ruleDescription?: string;
   progress?: CurrencyProgress;


### PR DESCRIPTION
## Problem

For freshly revalidated EASA PPL/CPL SEP/TMG/MEP/SET ratings (and IRs), the 12-month experience-counting window doesn't open until ~12 months before expiry. The card currently shows the same UI as "window open but nothing logged yet" — red/amber progress bars and an `expiring` badge — which is confusing because flights logged today don't count toward the next revalidation anyway.

## Solution

The API now sends two new fields (`windowOpensAt`, `windowOpen`) and omits `requirements` while the window is closed. The card responds:

- adds a subtle sky-blue info banner above the message:
  > 🕒 **Experience window opens 2027-05-15**  
  > Recently revalidated — flights logged before this date don't count toward the next revalidation.
- relies on the API to omit `requirements`, so no misleading red bars appear.

Once `windowOpen === true` (window has opened) the banner is hidden and the familiar requirement bars come back.

## Changes

- `src/api/schema.ts` — regenerated.
- `src/types/api.ts` — `ClassRatingCurrency` extended with `windowOpensAt` / `windowOpen`.
- `src/components/currency/CurrencyCard.tsx` — new banner gated on `windowOpensAt && windowOpen === false`.
- `src/i18n/locales/{en,de}/currency.json` — new `windowOpensLabel` and `windowClosedHint` keys.
- `src/__tests__/currency/CurrencyCard.test.tsx` — two new tests for the closed/open states.

## Companion PR

- API: fjaeckel/ninerlog-api `feat/revalidation-window-state` (computes the fields and suppresses requirements).

## Test plan

- `npx vitest run` — 271/271 tests pass locally.

## Screenshots

_To be added when running against the API branch._
