### PR TITLE
test(e2e): match envelope-only recipient in MailPit token lookup

### DIFF
--- a/src/__tests__/e2e/helpers.ts
+++ b/src/__tests__/e2e/helpers.ts
@@ -32,8 +32,12 @@ async function fetchVerificationToken(
   let lastErr = '';
   while (Date.now() < deadline) {
     try {
+      // The query intentionally omits the `to:` prefix. For security (CWE-640),
+      // the API delivers the recipient via the SMTP envelope only and omits the
+      // `To:` header, so MailPit records the recipient as Bcc. A bare-address
+      // query matches the message regardless of which header it lands in.
       const search = await request.get(
-        `${MAILPIT_URL}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
+        `${MAILPIT_URL}/api/v1/search?query=${encodeURIComponent(email)}`,
       );
       if (search.ok()) {
         const data: { messages: Array<{ ID: string; Subject: string }> } = await search.json();


### PR DESCRIPTION
## Problem

After the API hardened email delivery against header injection (CWE-640, ninerlog-api #64) by delivering the recipient via the SMTP envelope only and dropping the `To:` header, MailPit records the recipient as **Bcc** with a null `To` header.

The Playwright verification-token helper searched MailPit with `query=to:<email>`, which now matches nothing — so every registration-based e2e test failed with:

```
Error: Could not retrieve verification token for e2e-…@test.ninerlog.app
```

(19 of 87 tests failing before this change.)

## Fix

Drop the `to:` prefix from the MailPit search; a bare-address query matches the message whether the recipient lands in `To` or `Bcc`. No product behaviour is changed — this aligns the test helper with the intended secure email delivery.

## Verification

- `npx vitest run` ✅ (271 passed)
- Dockerized Playwright e2e ✅ (84 passed, 3 skipped, 0 failed — previously 19 failed)

## Related

- ninerlog-api #68 (the same envelope-recipient fix on the API e2e helpers, plus the logbook pagination bug this work uncovered)