### PR TITLE
feat(glider): glider flight form fields + EASA sailplane logbook export

### DIFF
--- a/src/__tests__/flights/FlightFormGlider.test.tsx
+++ b/src/__tests__/flights/FlightFormGlider.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FlightForm from '../../components/flights/FlightForm';
+
+// Aircraft list is swapped per test via this mutable ref.
+let mockAircraft: Array<Record<string, unknown>> = [];
+
+vi.mock('../../hooks/useFlights', () => ({
+  useCreateFlight: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+  useUpdateFlight: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useFlight: () => ({ data: null }),
+  useFlights: () => ({ data: { data: [] } }),
+}));
+
+vi.mock('../../hooks/useLicenses', () => ({
+  useLicenses: () => ({ data: [{ id: 'lic-1', licenseType: 'EASA_SPL', licenseNumber: 'SPL-001', isActive: true }] }),
+}));
+
+vi.mock('../../hooks/useAircraft', () => ({
+  useAircraft: () => ({ data: mockAircraft }),
+  useCreateAircraft: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../hooks/useContacts', () => ({
+  useSearchContacts: () => ({ data: [] }),
+  useCreateContact: () => ({ mutate: vi.fn() }),
+}));
+
+const glider = { id: 'ac-1', registration: 'D-1234', type: 'ASK21', aircraftClass: 'GLIDER', isActive: true };
+const sep = { id: 'ac-2', registration: 'D-EFGH', type: 'C172', aircraftClass: 'SEP_LAND', isActive: true };
+
+describe('FlightForm glider mode', () => {
+  const onClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAircraft = [];
+  });
+
+  it('hides launch fields for a powered (SEP) aircraft', async () => {
+    const user = userEvent.setup();
+    mockAircraft = [sep];
+    render(<FlightForm onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/Aircraft Registration/i), 'D-EFGH');
+
+    expect(screen.queryByLabelText('Launches')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/Release Altitude/i)).not.toBeInTheDocument();
+  });
+
+  it('shows launch method, launches and release altitude for a glider', async () => {
+    const user = userEvent.setup();
+    mockAircraft = [glider];
+    render(<FlightForm onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/Aircraft Registration/i), 'D-1234');
+
+    expect(screen.getByLabelText('Launches')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Release Altitude/i)).toBeInTheDocument();
+    // The expanded launch-method dropdown offers the new methods.
+    expect(screen.getByRole('option', { name: 'Bungee' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Auto-tow' })).toBeInTheDocument();
+  });
+
+  it('hides the IFR field for a pure sailplane', async () => {
+    const user = userEvent.setup();
+    mockAircraft = [glider];
+    render(<FlightForm onClose={onClose} />);
+
+    await user.type(screen.getByLabelText(/Aircraft Registration/i), 'D-1234');
+    // Advanced Times holds the IFR field; expand it.
+    await user.click(screen.getByText('Advanced Times'));
+
+    expect(screen.queryByLabelText('IFR Time')).not.toBeInTheDocument();
+  });
+});

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -2276,11 +2276,27 @@ export interface components {
              */
             isProficiencyCheck?: boolean;
             /**
-             * @description Launch method for glider/SPL flights (winch, aerotow, or self-launch)
+             * @description Launch method for glider/SPL flights (winch, aerotow, self-launch, bungee, or auto-tow)
              * @example winch
              * @enum {string|null}
              */
-            launchMethod?: "winch" | "aerotow" | "self-launch" | "null" | null;
+            launchMethod?: "winch" | "aerotow" | "self-launch" | "bungee" | "auto-tow" | "null" | null;
+            /**
+             * @description Number of launches on this flight (EASA FCL.140.S). Defaults to 1 for glider flights; a club training row may chain several launches in one entry. 0 for powered flights.
+             * @example 1
+             */
+            launches?: number;
+            /**
+             * @description Release / cable-break altitude in metres for winch and aerotow launches.
+             * @example 450
+             */
+            releaseAltitude?: number | null;
+            /**
+             * @description Reference datum for releaseAltitude (above ground level or above mean sea level).
+             * @example AGL
+             * @enum {string|null}
+             */
+            releaseAltitudeRef?: "AGL" | "AMSL" | "null" | null;
             /**
              * @description Name of the pilot-in-command for this flight (EASA AMC1 FCL.050 Col 12). Auto-set to "Self" when isPic=true, or to instructorName when isDual=true.
              * @example Self
@@ -2427,7 +2443,16 @@ export interface components {
             isFlightReview?: boolean;
             isProficiencyCheck?: boolean;
             /** @enum {string|null} */
-            launchMethod?: "winch" | "aerotow" | "self-launch" | "null" | null;
+            launchMethod?: "winch" | "aerotow" | "self-launch" | "bungee" | "auto-tow" | "null" | null;
+            /** @description Number of launches on this flight (EASA FCL.140.S). Defaults to 1 for glider flights, 0 for powered flights. */
+            launches?: number;
+            /** @description Release / cable-break altitude in metres for winch and aerotow launches. */
+            releaseAltitude?: number | null;
+            /**
+             * @description Reference datum for releaseAltitude (AGL or AMSL).
+             * @enum {string|null}
+             */
+            releaseAltitudeRef?: "AGL" | "AMSL" | "null" | null;
             /** @description Name of the PIC. Auto-set to "Self" when isPic=true, or to instructorName when isDual=true. */
             picName?: string | null;
             /** @description Multi-pilot time in minutes (EASA AMC1 FCL.050 Col 10) */
@@ -2493,7 +2518,16 @@ export interface components {
             isFlightReview?: boolean;
             isProficiencyCheck?: boolean;
             /** @enum {string|null} */
-            launchMethod?: "winch" | "aerotow" | "self-launch" | "null" | null;
+            launchMethod?: "winch" | "aerotow" | "self-launch" | "bungee" | "auto-tow" | "null" | null;
+            /** @description Number of launches on this flight (EASA FCL.140.S) */
+            launches?: number;
+            /** @description Release / cable-break altitude in metres for winch and aerotow launches. */
+            releaseAltitude?: number | null;
+            /**
+             * @description Reference datum for releaseAltitude (AGL or AMSL).
+             * @enum {string|null}
+             */
+            releaseAltitudeRef?: "AGL" | "AMSL" | "null" | null;
             /** @description Name of the PIC */
             picName?: string | null;
             /** @description Multi-pilot time in minutes */
@@ -6039,8 +6073,8 @@ export interface operations {
             query?: {
                 /** @description Filter flights for a specific logbook license */
                 logbookLicenseId?: string;
-                /** @description PDF format — easa (AMC1 FCL.050 two-page spread), faa (ASA/Jeppesen layout), or summary (simplified totals) */
-                format?: "easa" | "faa" | "summary";
+                /** @description PDF format — easa (AMC1 FCL.050 two-page spread), faa (ASA/Jeppesen layout), glider (EASA SPL sailplane logbook with launch columns), or summary (simplified totals) */
+                format?: "easa" | "faa" | "glider" | "summary";
                 /** @description Page size for the generated PDF. All sizes are rendered in landscape orientation. EASA format is laid out as a book-style two-page spread (left + right) intended for double-sided printing. */
                 page_size?: "a4" | "a5" | "letter";
             };

--- a/src/components/aircraft/AircraftForm.tsx
+++ b/src/components/aircraft/AircraftForm.tsx
@@ -8,7 +8,7 @@ import { extractApiError } from '../../lib/errors';
 
 const AIRCRAFT_CLASSES = [
   'SEP_LAND', 'SEP_SEA', 'MEP_LAND', 'MEP_SEA',
-  'SET_LAND', 'SET_SEA', 'TMG',
+  'SET_LAND', 'SET_SEA', 'TMG', 'GLIDER', 'OTHER',
 ] as const;
 
 const aircraftSchema = z.object({

--- a/src/components/flights/FlightForm.tsx
+++ b/src/components/flights/FlightForm.tsx
@@ -48,6 +48,9 @@ const flightSchema = z.object({
   isFlightReview: z.boolean(),
   isProficiencyCheck: z.boolean(),
   launchMethod: z.string().optional().or(z.literal('')),
+  launches: z.number().int().min(0).optional(),
+  releaseAltitude: z.number().int().min(0).optional(),
+  releaseAltitudeRef: z.string().optional().or(z.literal('')),
   // Phase 6c regulatory compliance fields
   picName: z.string().optional().or(z.literal('')),
   multiPilotTime: z.number().min(0),
@@ -152,6 +155,9 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
       isFlightReview: false,
       isProficiencyCheck: false,
       launchMethod: '',
+      launches: undefined,
+      releaseAltitude: undefined,
+      releaseAltitudeRef: '',
       picName: '',
       multiPilotTime: 0,
       fstdType: '',
@@ -189,6 +195,9 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
         isFlightReview: existingFlight.isFlightReview || false,
         isProficiencyCheck: existingFlight.isProficiencyCheck || false,
         launchMethod: existingFlight.launchMethod || '',
+        launches: existingFlight.launches ?? undefined,
+        releaseAltitude: existingFlight.releaseAltitude ?? undefined,
+        releaseAltitudeRef: existingFlight.releaseAltitudeRef || '',
         picName: existingFlight.picName || '',
         multiPilotTime: existingFlight.multiPilotTime || 0,
         fstdType: existingFlight.fstdType || '',
@@ -306,6 +315,9 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
   )?.aircraftClass;
   const showLaunchMethod = currentAircraftClass === 'TMG' || currentAircraftClass === 'GLIDER' ||
     (currentAircraftClass && currentAircraftClass.toLowerCase().includes('glider'));
+  // A pure sailplane (not a TMG/motorglider): no IFR or night privilege.
+  const isPureGlider = currentAircraftClass === 'GLIDER' ||
+    (!!currentAircraftClass && currentAircraftClass.toLowerCase().includes('glider') && currentAircraftClass !== 'TMG');
 
   const onSubmit = async (data: FlightFormData) => {
     try {
@@ -342,6 +354,9 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
         isFlightReview: data.isFlightReview,
         isProficiencyCheck: data.isProficiencyCheck,
         launchMethod: (data.launchMethod || null) as any,
+        ...(data.launches !== undefined && { launches: data.launches }),
+        releaseAltitude: data.releaseAltitude ?? null,
+        releaseAltitudeRef: (data.releaseAltitudeRef || null) as any,
         picName: crewMembers.find((m) => m.role === 'PIC')?.name ?? null,
         multiPilotTime: data.multiPilotTime,
         fstdType: data.fstdType || null,
@@ -671,12 +686,52 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
       {showLaunchMethod && (
         <fieldset>
           <legend className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-3">{t('fields.launchMethod')}</legend>
-          <select {...register('launchMethod')} id="launchMethod" className="input w-auto">
-            <option value="">{t('form.notSpecified')}</option>
-            <option value="winch">{t('form.winchLaunch')}</option>
-            <option value="aerotow">{t('form.aerotow')}</option>
-            <option value="self-launch">{t('form.selfLaunch')}</option>
-          </select>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 [&>*]:min-w-0">
+            <div>
+              <label htmlFor="launchMethod" className="form-label">{t('fields.launchMethod')}</label>
+              <select {...register('launchMethod')} id="launchMethod" className="input">
+                <option value="">{t('form.notSpecified')}</option>
+                <option value="winch">{t('form.winchLaunch')}</option>
+                <option value="aerotow">{t('form.aerotow')}</option>
+                <option value="self-launch">{t('form.selfLaunch')}</option>
+                <option value="bungee">{t('launchMethods.bungee')}</option>
+                <option value="auto-tow">{t('launchMethods.autoTow')}</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="launches" className="form-label">{t('fields.launches')}</label>
+              <input
+                {...register('launches', { valueAsNumber: true })}
+                type="number"
+                id="launches"
+                step="1"
+                min="0"
+                placeholder="1"
+                className="input"
+              />
+              <p className="form-helper">{t('form.launchesHelper')}</p>
+            </div>
+            <div>
+              <label htmlFor="releaseAltitude" className="form-label">{t('fields.releaseAltitude')}</label>
+              <input
+                {...register('releaseAltitude', { valueAsNumber: true })}
+                type="number"
+                id="releaseAltitude"
+                step="1"
+                min="0"
+                className="input"
+              />
+              <p className="form-helper">{t('form.metres')}</p>
+            </div>
+            <div>
+              <label htmlFor="releaseAltitudeRef" className="form-label">{t('fields.releaseAltitudeRef')}</label>
+              <select {...register('releaseAltitudeRef')} id="releaseAltitudeRef" className="input">
+                <option value="">{t('form.notSpecified')}</option>
+                <option value="AGL">AGL</option>
+                <option value="AMSL">AMSL</option>
+              </select>
+            </div>
+          </div>
           <p className="form-helper mt-1">{t('form.requiredForSpl')}</p>
         </fieldset>
       )}
@@ -852,18 +907,20 @@ export default function FlightForm({ flightId, onClose }: FlightFormProps) {
         {expandedSections.advanced && (
           <>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-            <div>
-              <label htmlFor="ifrTime" className="form-label">{t('fields.ifrTime')}</label>
-              <input
-                {...register('ifrTime', { valueAsNumber: true })}
-                type="number"
-                id="ifrTime"
-                step="1"
-                min="0"
-                className="input"
-              />
-              <p className="form-helper">Minutes</p>
-            </div>
+            {!isPureGlider && (
+              <div>
+                <label htmlFor="ifrTime" className="form-label">{t('fields.ifrTime')}</label>
+                <input
+                  {...register('ifrTime', { valueAsNumber: true })}
+                  type="number"
+                  id="ifrTime"
+                  step="1"
+                  min="0"
+                  className="input"
+                />
+                <p className="form-helper">Minutes</p>
+              </div>
+            )}
             <div>
               <label htmlFor="simulatedFlightTime" className="form-label">{t('fields.simulatedFlightTime')}</label>
               <input

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -26,7 +26,7 @@ export const exportDataJSON = () =>
 
 export const exportFlightsPDF = (
   logbookLicenseId?: string,
-  format?: 'easa' | 'faa' | 'summary',
+  format?: 'easa' | 'faa' | 'glider' | 'summary',
   pageSize?: 'a4' | 'a5' | 'letter',
 ) => {
   const params = new URLSearchParams();

--- a/src/i18n/locales/de/aircraft.json
+++ b/src/i18n/locales/de/aircraft.json
@@ -58,6 +58,8 @@
     "MEP_SEA": "MEP (See) — Mehrmotorig Kolben",
     "SET_LAND": "SET (Land) — Einmotorig Turboprop",
     "SET_SEA": "SET (See) — Einmotorig Turboprop",
-    "TMG": "TMG — Reisemotorsegler"
+    "TMG": "TMG — Reisemotorsegler",
+    "GLIDER": "GLIDER — Segelflugzeug",
+    "OTHER": "OTHER — Sonstige"
   }
 }

--- a/src/i18n/locales/de/flights.json
+++ b/src/i18n/locales/de/flights.json
@@ -62,6 +62,9 @@
     "endorsements": "Vermerke",
     "fstdType": "FSTD-Typ",
     "launchMethod": "Startart",
+    "launches": "Starts",
+    "releaseAltitude": "Ausklinkhöhe (m)",
+    "releaseAltitudeRef": "Höhenbezug",
     "distance": "Entfernung (NM)",
     "isCrossCountry": "Überlandflug",
     "isPic": "PIC",
@@ -74,7 +77,9 @@
   "launchMethods": {
     "winch": "Winde",
     "aerotow": "Flugzeugschlepp",
-    "selfLaunch": "Eigenstart"
+    "selfLaunch": "Eigenstart",
+    "bungee": "Gummiseilstart",
+    "autoTow": "Autoschlepp"
   },
   "approachTypes": {
     "ILS": "ILS",
@@ -216,6 +221,8 @@
     "winchLaunch": "Windenstart",
     "aerotow": "Flugzeugschlepp",
     "selfLaunch": "Eigenstart",
+    "launchesHelper": "Standard: 1",
+    "metres": "Meter",
     "minutes": "Minuten",
     "allLandings": "Alle Landungen",
     "function": "Funktion",

--- a/src/i18n/locales/en/aircraft.json
+++ b/src/i18n/locales/en/aircraft.json
@@ -58,6 +58,8 @@
     "MEP_SEA": "MEP (Sea) — Multi Engine Piston",
     "SET_LAND": "SET (Land) — Single Engine Turboprop",
     "SET_SEA": "SET (Sea) — Single Engine Turboprop",
-    "TMG": "TMG — Touring Motor Glider"
+    "TMG": "TMG — Touring Motor Glider",
+    "GLIDER": "GLIDER — Sailplane",
+    "OTHER": "OTHER — Other"
   }
 }

--- a/src/i18n/locales/en/flights.json
+++ b/src/i18n/locales/en/flights.json
@@ -62,6 +62,9 @@
     "endorsements": "Endorsements",
     "fstdType": "FSTD Type",
     "launchMethod": "Launch Method",
+    "launches": "Launches",
+    "releaseAltitude": "Release Altitude (m)",
+    "releaseAltitudeRef": "Altitude Ref",
     "distance": "Distance (NM)",
     "isCrossCountry": "Cross-Country",
     "isPic": "PIC",
@@ -74,7 +77,9 @@
   "launchMethods": {
     "winch": "Winch",
     "aerotow": "Aerotow",
-    "selfLaunch": "Self-Launch"
+    "selfLaunch": "Self-Launch",
+    "bungee": "Bungee",
+    "autoTow": "Auto-tow"
   },
   "approachTypes": {
     "ILS": "ILS",
@@ -216,6 +221,8 @@
     "winchLaunch": "Winch Launch",
     "aerotow": "Aerotow",
     "selfLaunch": "Self-Launch",
+    "launchesHelper": "Defaults to 1",
+    "metres": "Metres",
     "minutes": "Minutes",
     "allLandings": "All Landings",
     "function": "Function",

--- a/src/pages/export/ExportPage.tsx
+++ b/src/pages/export/ExportPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { exportFlightsCSV, exportDataJSON, exportFlightsPDF } from '../../hooks/useExport';
+import { useLicenses } from '../../hooks/useLicenses';
 
 export default function ExportPage() {
   const { t } = useTranslation('reports');
@@ -9,6 +10,8 @@ export default function ExportPage() {
   const [pdfFormat, setPdfFormat] = useState<'easa' | 'faa' | 'glider' | 'summary'>('easa');
   const [pdfPageSize, setPdfPageSize] = useState<'a4' | 'a5' | 'letter'>('a4');
   const [csvFormat, setCsvFormat] = useState<'standard' | 'easa' | 'faa'>('standard');
+  const [selectedLogbookLicenseId, setSelectedLogbookLicenseId] = useState<string>('all');
+  const { data: licenses = [], isLoading: licensesLoading } = useLicenses();
 
   const handleExport = async (format: 'csv' | 'json' | 'pdf') => {
     setExporting(format);
@@ -17,7 +20,11 @@ export default function ExportPage() {
       if (format === 'csv') {
         await exportFlightsCSV(csvFormat);
       } else if (format === 'pdf') {
-        await exportFlightsPDF(undefined, pdfFormat, pdfPageSize);
+        await exportFlightsPDF(
+          selectedLogbookLicenseId === 'all' ? undefined : selectedLogbookLicenseId,
+          pdfFormat,
+          pdfPageSize,
+        );
       } else {
         await exportDataJSON();
       }
@@ -93,6 +100,20 @@ export default function ExportPage() {
             {t('export.pdfDescription', 'Generate a formatted logbook PDF. Print it, sign it, and use it as a paper logbook.')}
           </p>
           <select
+            value={selectedLogbookLicenseId}
+            onChange={(e) => setSelectedLogbookLicenseId(e.target.value)}
+            className="input mb-3 text-sm"
+            aria-label={t('export.logbookScope', 'Logbook scope')}
+            disabled={licensesLoading}
+          >
+            <option value="all">{t('export.allLogbooks', 'All logbooks')}</option>
+            {licenses.map((lic) => (
+              <option key={lic.id} value={lic.id}>
+                {lic.regulatoryAuthority} {lic.licenseType} {lic.requiresSeparateLogbook ? `(${t('export.separateLogbook', 'separate')})` : ''}
+              </option>
+            ))}
+          </select>
+          <select
             value={pdfFormat}
             onChange={(e) => setPdfFormat(e.target.value as 'easa' | 'faa' | 'glider' | 'summary')}
             className="input mb-3 text-sm"
@@ -120,6 +141,9 @@ export default function ExportPage() {
           >
             {exporting === 'pdf' ? t('export.downloading') : t('export.download') + ' PDF Logbook'}
           </button>
+          <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">
+            {t('export.logbookScopeHint', 'Choose a specific license/logbook to avoid mixed exports across categories.')}
+          </p>
         </div>
 
         {/* Import Link */}

--- a/src/pages/export/ExportPage.tsx
+++ b/src/pages/export/ExportPage.tsx
@@ -6,7 +6,7 @@ export default function ExportPage() {
   const { t } = useTranslation('reports');
   const [exporting, setExporting] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [pdfFormat, setPdfFormat] = useState<'easa' | 'faa' | 'summary'>('easa');
+  const [pdfFormat, setPdfFormat] = useState<'easa' | 'faa' | 'glider' | 'summary'>('easa');
   const [pdfPageSize, setPdfPageSize] = useState<'a4' | 'a5' | 'letter'>('a4');
   const [csvFormat, setCsvFormat] = useState<'standard' | 'easa' | 'faa'>('standard');
 
@@ -94,12 +94,13 @@ export default function ExportPage() {
           </p>
           <select
             value={pdfFormat}
-            onChange={(e) => setPdfFormat(e.target.value as 'easa' | 'faa' | 'summary')}
+            onChange={(e) => setPdfFormat(e.target.value as 'easa' | 'faa' | 'glider' | 'summary')}
             className="input mb-3 text-sm"
             aria-label={t('export.pdfFormat', 'PDF format')}
           >
             <option value="easa">{t('export.easaLogbook')}</option>
             <option value="faa">{t('export.faaLogbook')}</option>
+            <option value="glider">{t('export.gliderLogbook', 'EASA Sailplane (SPL)')}</option>
             <option value="summary">{t('export.summaryReport')}</option>
           </select>
           <select


### PR DESCRIPTION
## Summary

Phase G1 frontend for glider/SPL operations. Pairs with ninerlog-api PR #71 (`feat/glider-spl-operations`). A glider pilot whose tools already understand a winch launch won't switch to a logbook that asks them to type "winch" into remarks — this makes launch data first-class in the flight form and gives sailplane pilots a separate, printable logbook.

## Changes

- **FlightForm**: for glider/TMG aircraft, the launch section now collects **launches** and **release altitude** (+ AGL/AMSL reference) alongside the launch method, which is expanded with **bungee** and **auto-tow**. Pure sailplanes hide the **IFR** field (no IFR privilege).
- **Export**: PDF export adds an **"EASA Sailplane (SPL)"** format that prints a sailplane-only logbook, separate from the aeroplane logbook.
- Regenerated API client from the updated OpenAPI spec; added en/de translations.

## Tests
- New `FlightFormGlider.test.tsx`: launch fields shown for gliders, hidden for powered aircraft; IFR hidden for sailplanes.
- Full vitest suite (286 tests) and `tsc --noEmit` green.

> Depends on the ninerlog-api glider PR (#71) for the new fields/endpoint params.