### PR TITLE
feat(auth): support no-SMTP registration success flow

### DIFF
--- a/src/__tests__/auth/RegisterPage.test.tsx
+++ b/src/__tests__/auth/RegisterPage.test.tsx
@@ -38,10 +38,15 @@ describe('RegisterPage', () => {
     isError: false,
     error: null,
   };
+  const mockResendVerification = {
+    mutateAsync: vi.fn(),
+    isPending: false,
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(useAuthHook, 'useRegister').mockReturnValue(mockRegister as any);
+    vi.spyOn(useAuthHook, 'useResendVerification').mockReturnValue(mockResendVerification as any);
   });
 
   afterEach(() => {
@@ -143,5 +148,50 @@ describe('RegisterPage', () => {
         expect.objectContaining({ preferredLocale: 'de' }),
       );
     });
+  });
+
+  it('shows check-email view when verification is required', async () => {
+    const user = userEvent.setup();
+    mockRegister.mutateAsync.mockResolvedValueOnce({
+      email: 'pilot@example.com',
+      verificationRequired: true,
+      message: 'verification required',
+    });
+
+    renderWithProviders(<RegisterPage />);
+
+    await user.type(screen.getByLabelText(/name/i), 'A Pilot');
+    await user.type(screen.getByLabelText(/^email/i), 'pilot@example.com');
+    await user.type(screen.getByLabelText(/^password/i), 'password1234');
+    await user.type(screen.getByLabelText(/confirm password/i), 'password1234');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('check-email-view')).toBeInTheDocument();
+    });
+  });
+
+  it('shows login-ready view when verification is not required', async () => {
+    const user = userEvent.setup();
+    mockRegister.mutateAsync.mockResolvedValueOnce({
+      email: 'pilot@example.com',
+      verificationRequired: false,
+      message: 'account ready',
+    });
+
+    renderWithProviders(<RegisterPage />);
+
+    await user.type(screen.getByLabelText(/name/i), 'A Pilot');
+    await user.type(screen.getByLabelText(/^email/i), 'pilot@example.com');
+    await user.type(screen.getByLabelText(/^password/i), 'password1234');
+    await user.type(screen.getByLabelText(/confirm password/i), 'password1234');
+    await user.click(screen.getByRole('button', { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-ready-view')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /log in now/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/login', { state: { email: 'pilot@example.com' } });
   });
 });

--- a/src/api/schema.ts
+++ b/src/api/schema.ts
@@ -15,10 +15,15 @@ export interface paths {
         put?: never;
         /**
          * Register a new user
-         * @description Create a new user account with email and password. A verification email is sent
-         *     to the provided address — the user must click the link in that email to confirm
-         *     their address before they can log in. No authentication tokens are returned
-         *     from this endpoint.
+         * @description Create a new user account with email and password.
+         *
+         *     When SMTP is configured, a verification email is sent to the provided address,
+         *     and the user must confirm it before they can log in.
+         *
+         *     When SMTP is not configured, the backend auto-verifies the new account so
+         *     registration and login remain usable in local/self-hosted setups.
+         *
+         *     No authentication tokens are returned from this endpoint.
          */
         post: operations["registerUser"];
         delete?: never;
@@ -1847,14 +1852,14 @@ export interface components {
         RegistrationResponse: {
             /**
              * Format: email
-             * @description Address the verification email was sent to
+             * @description Registered account email address
              * @example pilot@example.com
              */
             email: string;
             /** @example A verification email has been sent. Please check your inbox to complete registration. */
             message: string;
             /**
-             * @description Always true — clients should display a "check your email" message and not attempt login until verification completes.
+             * @description True when SMTP is configured and the user must verify via email; false when the backend auto-verifies because SMTP is not configured.
              * @example true
              */
             verificationRequired: boolean;
@@ -4081,11 +4086,17 @@ export interface operations {
                     password: string;
                     /** @example John Doe */
                     name: string;
+                    /**
+                     * @description Preferred language for the interface. Defaults to `en` when omitted.
+                     * @example en
+                     * @enum {string}
+                     */
+                    preferredLocale?: "en" | "de";
                 };
             };
         };
         responses: {
-            /** @description User created — verification email sent */
+            /** @description User created (verification may be required depending on SMTP configuration) */
             201: {
                 headers: {
                     [name: string]: unknown;

--- a/src/i18n/locales/de/auth.json
+++ b/src/i18n/locales/de/auth.json
@@ -49,6 +49,11 @@
       "description": "Wir haben einen Bestätigungslink an {{email}} gesendet. Klicken Sie auf den Link, um Ihr Konto zu aktivieren.",
       "resend": "Bestätigungs-E-Mail erneut senden",
       "resent": "Falls die Adresse registriert ist, haben wir gerade eine weitere Bestätigungs-E-Mail gesendet."
+    },
+    "accountReady": {
+      "title": "Konto bereit",
+      "description": "Ihr Konto für {{email}} ist aktiv. Sie können sich jetzt anmelden.",
+      "logInNow": "Jetzt anmelden"
     }
   },
   "resetPassword": {

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -49,6 +49,11 @@
       "description": "We sent a verification link to {{email}}. Click the link in that email to activate your account.",
       "resend": "Resend verification email",
       "resent": "If the address is registered, we just sent another verification email."
+    },
+    "accountReady": {
+      "title": "Account ready",
+      "description": "Your account for {{email}} is active. You can sign in now.",
+      "logInNow": "Log in now"
     }
   },
   "resetPassword": {

--- a/src/pages/auth/RegisterPage.tsx
+++ b/src/pages/auth/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -27,10 +27,12 @@ type RegisterFormData = z.infer<typeof registerSchema>;
 
 export default function RegisterPage() {
   const { t, i18n } = useTranslation('auth');
+  const navigate = useNavigate();
   const registerMutation = useRegister();
   const resendMutation = useResendVerification();
   const [error, setError] = useState<string | null>(null);
   const [registeredEmail, setRegisteredEmail] = useState<string | null>(null);
+  const [loginReadyEmail, setLoginReadyEmail] = useState<string | null>(null);
   const [resentNotice, setResentNotice] = useState(false);
 
   const detectedLanguage =
@@ -54,13 +56,21 @@ export default function RegisterPage() {
   const onSubmit = async (data: RegisterFormData) => {
     try {
       setError(null);
-      await registerMutation.mutateAsync({
+      setResentNotice(false);
+      const response = await registerMutation.mutateAsync({
         email: data.email,
         password: data.password,
         name: data.name,
         preferredLocale: data.language,
       });
-      setRegisteredEmail(data.email);
+
+      if (response.verificationRequired) {
+        setLoginReadyEmail(null);
+        setRegisteredEmail(response.email ?? data.email);
+      } else {
+        setRegisteredEmail(null);
+        setLoginReadyEmail(response.email ?? data.email);
+      }
     } catch (err: unknown) {
       const status = extractApiStatus(err);
       if (status === 409) {
@@ -133,6 +143,22 @@ export default function RegisterPage() {
                 {t('auth:register.logIn')}
               </Link>
             </p>
+          </div>
+        ) : loginReadyEmail ? (
+          <div className="card p-6 space-y-4" data-testid="login-ready-view">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {t('auth:register.accountReady.title')}
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {t('auth:register.accountReady.description', { email: loginReadyEmail })}
+            </p>
+            <button
+              type="button"
+              onClick={() => navigate('/login', { state: { email: loginReadyEmail } })}
+              className="btn-primary w-full"
+            >
+              {t('auth:register.accountReady.logInNow')}
+            </button>
           </div>
         ) : (
           <form


### PR DESCRIPTION
## Summary
- handle `verificationRequired=false` from `POST /auth/register`
- show a new "account ready" state when the backend auto-verifies accounts
- keep existing "check your email" flow when verification is required
- add EN/DE translation strings for the login-ready state
- extend `RegisterPage` tests for both registration response paths
- regenerate frontend API schema from local updated OpenAPI spec

## Why
With the backend no-SMTP auto-verification behavior, registration should not always force a verification-email UI state.

## Testing
- `npx vitest run src/__tests__/auth/RegisterPage.test.tsx`
- `npx tsc --noEmit`