### PR TITLE
chore(dashboard): remove Time by Authority section

### DIFF
--- a/src/i18n/locales/de/dashboard.json
+++ b/src/i18n/locales/de/dashboard.json
@@ -39,7 +39,6 @@
     "IR": "IR",
     "OTHER": "Sonstige"
   },
-  "timeByAuthority": "Zeit nach Behörde",
   "recentFlights": "Letzte Flüge",
   "noFlights": "Noch keine Flüge eingetragen",
   "logFirstFlight": "Ersten Flug eintragen",

--- a/src/i18n/locales/en/dashboard.json
+++ b/src/i18n/locales/en/dashboard.json
@@ -39,7 +39,6 @@
     "IR": "IR",
     "OTHER": "Other"
   },
-  "timeByAuthority": "Time by Authority",
   "recentFlights": "Recent Flights",
   "noFlights": "No flights logged yet",
   "logFirstFlight": "Log Your First Flight",

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -198,22 +198,6 @@ export default function DashboardPage() {
         </div>
       )}
 
-      {/* Time by Authority */}
-      {classStat && classStat.byAuthority.length > 0 && (
-        <div className="card mb-6">
-          <h2 className="section-title mb-4">{t('dashboard:timeByAuthority')}</h2>
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-            {classStat.byAuthority.map((auth) => (
-              <div key={`${auth.authority}-${auth.licenseType}`} className="text-center p-3 bg-slate-50 dark:bg-slate-800/50 rounded-lg">
-                <p className="data-lg text-slate-800 dark:text-slate-100">{fmtDuration(auth.minutes)}</p>
-                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">{auth.authority} {auth.licenseType}</p>
-                <p className="text-xs text-slate-400 dark:text-slate-500 font-mono tabular-nums">{auth.flights} {t('common:flights')}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-
       {/* Recent Flights */}
       <div className="card mb-6">
         <div className="flex justify-between items-center mb-4">


### PR DESCRIPTION
## Summary
- remove the `Time by Authority` section from the dashboard UI
- remove the now-unused `dashboard.timeByAuthority` translation key in EN/DE locale files

## Changes
- `src/pages/DashboardPage.tsx`
  - removed the `classStat.byAuthority` card block and heading
- `src/i18n/locales/en/dashboard.json`
  - removed `timeByAuthority`
- `src/i18n/locales/de/dashboard.json`
  - removed `timeByAuthority`

## Validation
- ✅ `npx tsc --noEmit` (frontend)
- ✅ `npx vitest run` (frontend unit tests; passing with 32 files / 289 tests)
- ❌ `npx playwright test` (frontend e2e) currently failing in local env due pre-existing environment/setup issues:
  - missing MailPit host (`mailpit-test`) for verification-token lookup in e2e helpers
  - auth-flow assertions expecting `check-email-view` did not match runtime behavior in several tests
- ✅ `go test ./...` (api)
- ℹ️ `bash scripts/run-e2e-tests.sh` (api) was started and showed ongoing passing suites during run; final completion summary could not be captured in this session due output truncation.

## Notes
This PR is intentionally scoped to dashboard UI cleanup only.